### PR TITLE
Fix build when using the static linux SDK

### DIFF
--- a/Sources/ToolsProtocolsTestSupport/Assertions.swift
+++ b/Sources/ToolsProtocolsTestSupport/Assertions.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(XCTest)
 package import XCTest
 
 /// Same as `XCTAssertNoThrow` but executes the trailing closure.
@@ -181,3 +182,4 @@ package nonisolated func fulfillmentOfOrThrow(
     throw ExpectationNotFulfilledError(expectations: expectations)
   }
 }
+#endif

--- a/Sources/ToolsProtocolsTestSupport/CheckCoding.swift
+++ b/Sources/ToolsProtocolsTestSupport/CheckCoding.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(XCTest)
 import Foundation
 import XCTest
 
@@ -112,3 +113,4 @@ package func checkCoding<T: Codable>(
 
   body(decodedValue)
 }
+#endif

--- a/Sources/ToolsProtocolsTestSupport/PerfTestCase.swift
+++ b/Sources/ToolsProtocolsTestSupport/PerfTestCase.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(XCTest)
 public import XCTest
 
 /// Base class for a performance test case in SourceKit-LSP.
@@ -52,3 +53,4 @@ open class PerfTestCase: XCTestCase {
   #endif
 
 }
+#endif

--- a/Sources/ToolsProtocolsTestSupport/RepeatUntilExpectedResult.swift
+++ b/Sources/ToolsProtocolsTestSupport/RepeatUntilExpectedResult.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(XCTest)
 import SKLogging
 @_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
 import XCTest
@@ -35,3 +36,4 @@ package func repeatUntilExpectedResult(
   }
   XCTFail("Failed to get expected result", file: file, line: line)
 }
+#endif

--- a/Sources/ToolsProtocolsTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/ToolsProtocolsTestSupport/TestJSONRPCConnection.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(XCTest)
 public import LanguageServerProtocol
 package import LanguageServerProtocolTransport
 @_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
@@ -233,3 +234,4 @@ package struct EchoNotification: NotificationType {
     self.string = string
   }
 }
+#endif


### PR DESCRIPTION
Wrap most of the TestSupport target in canImport checks so it builds when XCTest isn't available