### PR TITLE
bspProtocol should be a static member of MessageRegistry

### DIFF
--- a/Sources/BuildServerProtocol/Messages.swift
+++ b/Sources/BuildServerProtocol/Messages.swift
@@ -38,7 +38,7 @@ private let notificationTypes: [NotificationType.Type] = [
 ]
 
 extension MessageRegistry {
-  public var bspProtocol: MessageRegistry {
+  public static var bspProtocol: MessageRegistry {
     MessageRegistry(requests: requestTypes, notifications: notificationTypes)
   }
 }


### PR DESCRIPTION
This was an instance member on accident