### PR TITLE
Export 'ForPlugin' targets in the CMake build

### DIFF
--- a/Sources/SKLogging/CMakeLists.txt
+++ b/Sources/SKLogging/CMakeLists.txt
@@ -16,16 +16,17 @@ target_link_libraries(SKLogging PRIVATE
 target_link_libraries(SKLogging PUBLIC
   ToolsProtocolsSwiftExtensions)
 
-add_library(SKLoggingForPlugin STATIC ${sources})
-set_target_properties(SKLoggingForPlugin PROPERTIES
+add_library(_SKLoggingForPlugin STATIC ${sources})
+set_target_properties(_SKLoggingForPlugin PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-target_compile_options(SKLoggingForPlugin PRIVATE
+target_compile_options(_SKLoggingForPlugin PRIVATE
   $<$<COMPILE_LANGUAGE:Swift>:
-    "SHELL:-module-alias ToolsProtocolsSwiftExtensions=ToolsProtocolsSwiftExtensionsForPlugin"
+    "SHELL:-module-alias ToolsProtocolsSwiftExtensions=_ToolsProtocolsSwiftExtensionsForPlugin"
   >)
-target_link_libraries(SKLoggingForPlugin PRIVATE
+target_link_libraries(_SKLoggingForPlugin PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
-target_link_libraries(SKLoggingForPlugin PUBLIC
-  ToolsProtocolsSwiftExtensionsForPlugin)
+target_link_libraries(_SKLoggingForPlugin PUBLIC
+  _ToolsProtocolsSwiftExtensionsForPlugin)
 
 set_property(GLOBAL APPEND PROPERTY SWIFTTOOLSPROTOCOLS_EXPORTS SKLogging)
+set_property(GLOBAL APPEND PROPERTY SWIFTTOOLSPROTOCOLS_EXPORTS _SKLoggingForPlugin)

--- a/Sources/ToolsProtocolsSwiftExtensions/CMakeLists.txt
+++ b/Sources/ToolsProtocolsSwiftExtensions/CMakeLists.txt
@@ -20,12 +20,13 @@ target_link_libraries(ToolsProtocolsSwiftExtensions PUBLIC
 target_link_libraries(ToolsProtocolsSwiftExtensions PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 
-add_library(ToolsProtocolsSwiftExtensionsForPlugin STATIC ${sources})
-set_target_properties(ToolsProtocolsSwiftExtensionsForPlugin PROPERTIES
+add_library(_ToolsProtocolsSwiftExtensionsForPlugin STATIC ${sources})
+set_target_properties(_ToolsProtocolsSwiftExtensionsForPlugin PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-target_link_libraries(ToolsProtocolsSwiftExtensionsForPlugin PUBLIC
+target_link_libraries(_ToolsProtocolsSwiftExtensionsForPlugin PUBLIC
   ToolsProtocolsCAtomics)
-target_link_libraries(ToolsProtocolsSwiftExtensionsForPlugin PRIVATE
+target_link_libraries(_ToolsProtocolsSwiftExtensionsForPlugin PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 
 set_property(GLOBAL APPEND PROPERTY SWIFTTOOLSPROTOCOLS_EXPORTS ToolsProtocolsSwiftExtensions)
+set_property(GLOBAL APPEND PROPERTY SWIFTTOOLSPROTOCOLS_EXPORTS _ToolsProtocolsSwiftExtensionsForPlugin)


### PR DESCRIPTION
These need to be exported so the CMake build of sourcekit-lsp on Windows can find them. While I'm here, rename them to mirror the names used in the SwiftPM build