### PR TITLE
Don't specify explicit linkage for CMake targets

### DIFF
--- a/Sources/BuildServerProtocol/CMakeLists.txt
+++ b/Sources/BuildServerProtocol/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(BuildServerProtocol STATIC
+add_library(BuildServerProtocol
   Messages.swift
 
   Messages/BuildShutdownRequest.swift

--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(LanguageServerProtocol STATIC
+add_library(LanguageServerProtocol
   Connection.swift
   CustomCodable.swift
   Error.swift

--- a/Sources/LanguageServerProtocolTransport/CMakeLists.txt
+++ b/Sources/LanguageServerProtocolTransport/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(LanguageServerProtocolTransport STATIC
+add_library(LanguageServerProtocolTransport
   BuildServerMessageDependencyTracker.swift
   DisableSigpipe.swift
   DocumentURI+CustomLogStringConvertible.swift

--- a/Sources/SKLogging/CMakeLists.txt
+++ b/Sources/SKLogging/CMakeLists.txt
@@ -8,7 +8,7 @@ set(sources
   SetGlobalLogFileHandler.swift
   SplitLogMessage.swift)
 
-add_library(SKLogging STATIC ${sources})
+add_library(SKLogging ${sources})
 set_target_properties(SKLogging PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(SKLogging PRIVATE
@@ -16,7 +16,7 @@ target_link_libraries(SKLogging PRIVATE
 target_link_libraries(SKLogging PUBLIC
   ToolsProtocolsSwiftExtensions)
 
-add_library(_SKLoggingForPlugin STATIC ${sources})
+add_library(_SKLoggingForPlugin ${sources})
 set_target_properties(_SKLoggingForPlugin PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_compile_options(_SKLoggingForPlugin PRIVATE

--- a/Sources/ToolsProtocolsSwiftExtensions/CMakeLists.txt
+++ b/Sources/ToolsProtocolsSwiftExtensions/CMakeLists.txt
@@ -12,7 +12,7 @@ set(sources
   URLExtensions.swift
 )
 
-add_library(ToolsProtocolsSwiftExtensions STATIC ${sources})
+add_library(ToolsProtocolsSwiftExtensions ${sources})
 set_target_properties(ToolsProtocolsSwiftExtensions PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(ToolsProtocolsSwiftExtensions PUBLIC
@@ -20,7 +20,7 @@ target_link_libraries(ToolsProtocolsSwiftExtensions PUBLIC
 target_link_libraries(ToolsProtocolsSwiftExtensions PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 
-add_library(_ToolsProtocolsSwiftExtensionsForPlugin STATIC ${sources})
+add_library(_ToolsProtocolsSwiftExtensionsForPlugin ${sources})
 set_target_properties(_ToolsProtocolsSwiftExtensionsForPlugin PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(_ToolsProtocolsSwiftExtensionsForPlugin PUBLIC


### PR DESCRIPTION
Instead let clients control this using -DBUILD_SHARED_LIBS