### PR TITLE
LoggingScope's task local APIs had incorrect sendable annotations

### DIFF
--- a/Sources/SKLogging/LoggingScope.swift
+++ b/Sources/SKLogging/LoggingScope.swift
@@ -75,7 +75,7 @@ public final class LoggingScope {
 @_spi(SourceKitLSP) public func withLoggingSubsystemAndScope<Result>(
   subsystem: String,
   scope: String?,
-  _ operation: @Sendable () throws -> Result
+  _ operation: () throws -> Result
 ) rethrows -> Result {
   return try LoggingScope.$_subsystem.withValue(subsystem) {
     return try LoggingScope.$_scope.withValue(scope, operation: operation)
@@ -86,7 +86,7 @@ public final class LoggingScope {
 @_spi(SourceKitLSP) public func withLoggingSubsystemAndScope<Result>(
   subsystem: String,
   scope: String?,
-  @_inheritActorContext _ operation: @Sendable @concurrent () async throws -> Result
+  _ operation: nonisolated(nonsending) () async throws -> Result
 ) async rethrows -> Result {
   return try await LoggingScope.$_subsystem.withValue(subsystem) {
     return try await LoggingScope.$_scope.withValue(scope, operation: operation)
@@ -114,9 +114,9 @@ public final class LoggingScope {
 /// Same as `withLoggingScope` but allows the operation to be `async`.
 ///
 /// - SeeAlso: ``withLoggingScope(_:_:)-6qtga``
-@_spi(SourceKitLSP) public func withLoggingScope<Result>(
+@_spi(SourceKitLSP) public nonisolated(nonsending) func withLoggingScope<Result>(
   _ scope: String,
-  @_inheritActorContext _ operation: @Sendable @concurrent () async throws -> Result
+  _ operation: nonisolated(nonsending) () async throws -> Result
 ) async rethrows -> Result {
   return try await LoggingScope.$_scope.withValue(
     scope,


### PR DESCRIPTION
These functions must not be Sendable, this will start failing in future builds.

Related to rdar://174026465