### PR TITLE
[LSP] 'workspace/symbolNames' and 'workspace/symbolInfo' extension

### DIFF
--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -97,6 +97,8 @@ add_library(LanguageServerProtocol
   Requests/WorkspacePlaygroundsRefreshRequest.swift
   Requests/WorkspacePlaygroundsRequest.swift
   Requests/WorkspaceSemanticTokensRefreshRequest.swift
+  Requests/WorkspaceSymbolInfoRequest.swift
+  Requests/WorkspaceSymbolNamesRequest.swift
   Requests/WorkspaceSymbolResolveRequest.swift
   Requests/WorkspaceSymbolsRequest.swift
   Requests/WorkspaceTestsRefreshRequest.swift

--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -90,6 +90,8 @@ public let builtinRequests: [_RequestType.Type] = [
   WorkspacePlaygroundsRefreshRequest.self,
   WorkspacePlaygroundsRequest.self,
   WorkspaceSemanticTokensRefreshRequest.self,
+  WorkspaceSymbolInfoRequest.self,
+  WorkspaceSymbolNamesRequest.self,
   WorkspaceSymbolResolveRequest.self,
   WorkspaceSymbolsRequest.self,
   WorkspaceTestsRefreshRequest.self,

--- a/Sources/LanguageServerProtocol/Requests/WorkspaceSymbolInfoRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/WorkspaceSymbolInfoRequest.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Returns structured location information for a list of exact symbol names.
+///
+/// Unlike the standard `workspace/symbol` request (which accepts a fuzzy query string),
+/// this request takes exact names — typically obtained from ``WorkspaceAllSymbolNamesRequest`` —
+/// and returns all index occurrences for each name across every workspace.
+///
+/// For each name the response contains zero or more ``WorkspaceSymbolItem`` values:
+/// - Source-file symbols carry a `SymbolInformation` with a `file://` URI and the exact 0-based
+///   line/column.
+/// - SDK/stdlib symbols carry a `WorkspaceSymbol` with `location: .uri(...)` pointing at the
+///   `file://` URI of the `.swiftinterface` or `.swiftmodule` file from the index record, with the
+///   fully-qualified module name appended as a `?module=` query parameter. The symbol's USR is
+///   stored in `data["usr"]`. Call `workspaceSymbol/resolve` to obtain the exact ``Location``
+///   within the generated interface. The client must advertise `workspace.symbol.resolveSupport`;
+///   without it, the raw `file://` URI is returned as `SymbolInformation` instead.
+///
+/// **(LSP Extension)**
+public struct WorkspaceSymbolInfoRequest: LSPRequest, Hashable {
+
+  public static let method: String = "sourcekit/workspace/symbolInfo"
+  public typealias Response = WorkspaceSymbolInfoResponse
+
+  /// Symbol names to match.
+  public var names: [String]
+
+  public init(names: [String]) {
+    self.names = names
+  }
+}
+
+/// Response to a `workspace/symbolInfo` request.
+public struct WorkspaceSymbolInfoResponse: ResponseType {
+  public var results: [WorkspaceSymbolItem]
+
+  public init(results: [WorkspaceSymbolItem]) {
+    self.results = results
+  }
+}

--- a/Sources/LanguageServerProtocol/Requests/WorkspaceSymbolNamesRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/WorkspaceSymbolNamesRequest.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Returns the flat, deduplicated list of every symbol name in the workspace index, including
+/// names from indexed system modules (stdlib, SDK frameworks).
+///
+/// Clients use this list to drive a local search UI (fuzzy matching, prefix filtering, etc.)
+/// without a round-trip per keystroke. After the user selects a name, send a
+/// ``WorkspaceSymbolInfoRequest`` to resolve it to concrete locations.
+///
+/// **(LSP Extension)**
+public struct WorkspaceSymbolNamesRequest: LSPRequest, Hashable {
+
+  public static let method: String = "sourcekit/workspace/symbolNames"
+  public typealias Response = WorkspaceSymbolNamesResponse
+
+  public init() {}
+}
+
+/// Response to a `workspace/symbolNames` request.
+public struct WorkspaceSymbolNamesResponse: ResponseType {
+  public var names: [String]
+
+  public init(names: [String]) {
+    self.names = names
+  }
+}

--- a/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
@@ -100,14 +100,52 @@ public struct WorkspaceClientCapabilities: Hashable, Codable, Sendable {
       }
     }
 
+    /// The tags supported by the client for `workspace/symbol`.
+    public struct TagSupport: Hashable, Codable, Sendable {
+      /// The tags supported by the client.
+      public var valueSet: [SymbolTag]
+
+      public init(valueSet: [SymbolTag]) {
+        self.valueSet = valueSet
+      }
+    }
+
+    /// Properties the client can resolve lazily via `workspaceSymbol/resolve`.
+    public struct ResolveSupport: Hashable, Codable, Sendable {
+      /// The properties that a client can resolve lazily. Usually `"location.range"`.
+      public var properties: [String]
+
+      public init(properties: [String]) {
+        self.properties = properties
+      }
+    }
+
     /// Whether the client supports dynamic registration of this request.
     public var dynamicRegistration: Bool? = nil
 
     public var symbolKind: SymbolKindValueSet? = nil
 
-    public init(dynamicRegistration: Bool? = nil, symbolKind: SymbolKindValueSet? = nil) {
+    /// The client supports tags on `SymbolInformation` and `WorkspaceSymbol`.
+    /// Clients supporting tags have to handle unknown tags gracefully.
+    ///
+    /// Since LSP 3.16.
+    public var tagSupport: TagSupport? = nil
+
+    /// The client supports lazy resolution of `WorkspaceSymbol` properties via `workspaceSymbol/resolve`.
+    ///
+    /// Since LSP 3.17.
+    public var resolveSupport: ResolveSupport? = nil
+
+    public init(
+      dynamicRegistration: Bool? = nil,
+      symbolKind: SymbolKindValueSet? = nil,
+      tagSupport: TagSupport? = nil,
+      resolveSupport: ResolveSupport? = nil
+    ) {
       self.dynamicRegistration = dynamicRegistration
       self.symbolKind = symbolKind
+      self.tagSupport = tagSupport
+      self.resolveSupport = resolveSupport
     }
   }
 


### PR DESCRIPTION
`sourcekit/workspace/symbolNames` returns a flat list of every indexed symbol name in the workspace. Clients use this as the completion source for a fuzzy-search prompt.

`sourcekit/workspace/symbolInfo` accepts a list of names and returns matching `WorkspaceSymbol` / `SymbolInformation` values. Source-file symbols are returned as `SymbolInformation` with a `file://` URI and exact 0-based line/column. SDK and stdlib symbols are returned as `WorkspaceSymbol` with a `file://` URI pointing at the `.swiftinterface`/`.swiftmodule` index record (plus a `?module=` query parameter) and the USR stored in `data["usr"]`. Clients that advertise `workspace.symbol.resolveSupport` can call `workspaceSymbol/resolve` to obtain the precise location inside the generated interface.

Also adds `TagSupport` and `ResolveSupport` to `WorkspaceClientCapabilities.Symbol` to reflect LSP 3.16/3.17 capabilities.