### PR TITLE
Update platform versions in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -207,9 +207,9 @@ if buildOnlyTests {
 let package = Package(
   name: "swift-tools-protocols",
   platforms: [
-    .macOS(.v14),
-    .iOS(.v17),
-    .macCatalyst(.v17),
+    .macOS(.v15),
+    .iOS(.v18),
+    .macCatalyst(.v18),
   ],
   products: products,
   dependencies: dependencies,


### PR DESCRIPTION
We need to raise the minimum deployment target so that we can begin using macOS 15 APIs like Atomic.

This follows the sourcekit-lsp update in swiftlang/sourcekit-lsp#2636 and the swift-package-manager update in swiftlang/swift-package-manager#10043 and the swift-build update in swiftlang/swift-build#1387

This will allow removing the clunky ToolsProtocolsCAtomics workaround, unblocking resolution of #1949 via #1969