### PR TITLE
[Prototype] Rewrite JSONRPCConnection as an actor with AsyncStream

### DIFF
--- a/Sources/LanguageServerProtocolTransport/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolTransport/JSONRPCConnection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -19,44 +19,32 @@ public import LanguageServerProtocol
 import Android
 #endif
 
-#if canImport(CDispatch)
-import struct CDispatch.dispatch_fd_t
-#endif
-
 /// A connection between a message handler (e.g. language server) in the same process as the connection object and a
 /// remote message handler (e.g. language client) that may run in another process using JSON RPC messages sent over a
 /// pair of in/out file descriptors.
-///
-/// For example, inside a language server, the `JSONRPCConnection` takes the language service implementation as its
-/// `receiveHandler` and itself provides the client connection for sending notifications and callbacks.
-public final class JSONRPCConnection: Connection {
+public actor JSONRPCConnection: Connection {
   @frozen public enum TerminationReason: Sendable, Equatable {
-    /// The process on the other end of the `JSONRPCConnection` terminated with the given exit code.
     case exited(exitCode: Int32)
-
-    /// The process on the other end of the `JSONRPCConnection` terminated with a signal. The signal that it terminated
-    /// with is not known.
     case uncaughtSignal
   }
 
+  // MARK: - Outgoing work item
+
+  /// All outgoing sends are serialized through an `AsyncStream<OutgoingItem>`.
+  /// The stream's `Continuation.yield` is synchronous and thread-safe, giving a guaranteed FIFO
+  /// order that `Task { await … }` cannot provide.
+  private enum OutgoingItem: Sendable {
+    case notification(any NotificationType)
+    /// Pre-built `OutstandingRequest` so the actor can register it before the bytes hit the wire.
+    case request(any RequestType, id: RequestID, outstanding: OutstandingRequest)
+    case reply(LSPResult<any ResponseType>, id: RequestID)
+    case rawData(Data)
+  }
+
+  // MARK: - Constants (let properties are implicitly nonisolated)
+
   /// A name of the endpoint for this connection, used for logging, e.g. `clangd`.
   private let name: String
-
-  /// The message handler that handles requests and notifications sent through this connection.
-  ///
-  /// - Important: Must only be accessed from `queue`, or in `init`/`deinit` to avoid data races.
-  nonisolated(unsafe) private var receiveHandler: MessageHandler? = nil
-
-  /// Queue for synchronizing all messages to ensure they remain in order
-  private let queue: DispatchQueue
-
-  /// Queue for the read loop (effectively just a separate thread - we never yield from the initial task)
-  private let receiveQueue: DispatchQueue
-
-  /// Queue for sending any data through `sendFD`. This is currently needed as the read loop is blocked on messages
-  /// being parsed on `queue` (in order to not add an extra copy), so we must perform any corresponding sends off of
-  /// `queue`. If we ever change that, we can likely remove this queue.
-  private let sendQueue: DispatchQueue
 
   /// File descriptor for reading input (eg. stdin for an LSP server)
   private let receiveFD: FileHandle
@@ -69,83 +57,50 @@ public final class JSONRPCConnection: Connection {
   private let sendMirrorFile: FileHandle?
 
   private let messageRegistry: MessageRegistry
+  private let nextRequestIDStorage = AtomicUInt32(initialValue: 0)
 
-  enum State {
-    case created, running, closed
-  }
+  // MARK: - Send-path (created in init — independent of receiveHandler/closeHandler)
 
-  /// Current state of the connection, used to ensure correct usage.
-  ///
-  /// Access to this must be be guaranteed to be sequential to avoid data races. Currently, all access are:
-  ///  - `init`: Reference to `JSONRPCConnection` trivially can't have escaped to other isolation domains yet.
-  ///  - `start`: Synchronized on `queue`.
-  ///  - `closeAssumingOnQueue`: Synchronized on `queue`.
-  ///  - `readyToSend`: Synchronized on `queue`.
-  ///  - `deinit`: Can also only trivially be called once.
-  private nonisolated(unsafe) var state: State = .created
+  /// Yields to this continuation to enqueue an outgoing work item.
+  /// `AsyncStream.Continuation` is `Sendable`; as a `let` property it is implicitly `nonisolated`.
+  private let outgoingContinuation: AsyncStream<OutgoingItem>.Continuation
 
-  /// An integer that hasn't been used for a request ID yet.
-  let nextRequestIDStorage = AtomicUInt32(initialValue: 0)
+  /// Yields encoded bytes to this continuation for writing to `sendFD`.
+  /// Only accessed from the actor-isolated `outgoingProcessorTask`.
+  private let sendContinuation: AsyncStream<Data>.Continuation
 
-  struct OutstandingRequest: Sendable {
+  /// Drains `sendContinuation` and writes bytes to `sendFD` (detached — blocking I/O).
+  /// Awaiting this in `_close()` transitively waits for the outgoing processor to finish too,
+  /// because the processor calls `sendContinuation.finish()` before `sendLoopTask` can exit.
+  /// Assigned last in `init` so that `self` is fully initialized before the fire-and-forget
+  /// outgoing processor task captures it.
+  private let sendLoopTask: Task<Void, Never>
+
+  // MARK: - Receive-path (created in start — begins actual I/O)
+
+  /// Decodes and dispatches incoming messages on the actor.
+  /// `nil` until `start(receiveHandler:closeHandler:)` is called.
+  private var receiveLoopTask: Task<Void, Never>? = nil
+
+  // MARK: - Actor-isolated mutable state
+
+  private var receiveHandler: MessageHandler? = nil
+  private var closeHandler: (@Sendable () async -> Void)? = nil
+
+  private enum State { case running, closing, closed }
+  private var state: State = .running
+
+  private struct OutstandingRequest: Sendable {
+    var requestMethod: String
     var responseType: ResponseType.Type
     var replyHandler: @Sendable (LSPResult<Any>) -> Void
   }
 
   /// The set of currently outstanding outgoing requests along with information about how to decode and handle their
   /// responses.
-  ///
-  /// All accesses to `outstandingRequests` must be on `queue` to avoid race conditions.
-  private nonisolated(unsafe) var outstandingRequests: [RequestID: OutstandingRequest] = [:]
+  private var outstandingRequests: [RequestID: OutstandingRequest] = [:]
 
-  /// A handler that will be called asynchronously when the connection is being
-  /// closed.
-  ///
-  /// There are no race conditions to `closeHandler` because it is only set from `start`, which is required to be called
-  /// in the same serial code region domain as the initializer, so it's serial and the `JSONRPCConnection` can't
-  /// have escaped to other isolation domains yet.
-  private nonisolated(unsafe) var closeHandler: (@Sendable () async -> Void)? = nil
-
-  /// - Important: `start` must be called before sending any data over the `JSONRPCConnection`.
-  @available(*, deprecated, message: "Use init(name:protocol:receiveFD:sendFD:receiveMirrorFile:sendMirrorFile instead")
-  public convenience init(
-    name: String,
-    protocol messageRegistry: MessageRegistry,
-    inFD: FileHandle,
-    outFD: FileHandle,
-    inputMirrorFile: FileHandle? = nil,
-    outputMirrorFile: FileHandle? = nil
-  ) {
-    self.init(
-      name: name,
-      protocol: messageRegistry,
-      receiveFD: inFD,
-      sendFD: outFD,
-      receiveMirrorFile: inputMirrorFile,
-      sendMirrorFile: outputMirrorFile
-    )
-  }
-
-  /// - Important: `start` must be called before sending any data over the `JSONRPCConnection`.
-  public init(
-    name: String,
-    protocol messageRegistry: MessageRegistry,
-    receiveFD: FileHandle,
-    sendFD: FileHandle,
-    receiveMirrorFile: FileHandle? = nil,
-    sendMirrorFile: FileHandle? = nil
-  ) {
-    self.name = name
-    self.queue = DispatchQueue(label: "\(name)-jsonrpc-queue", qos: .userInitiated)
-    self.receiveQueue = DispatchQueue(label: "\(name)-jsonrpc-read-queue", qos: .userInitiated)
-    self.sendQueue = DispatchQueue(label: "\(name)-jsonrpc-send-queue", qos: .userInitiated)
-    self.receiveFD = receiveFD
-    self.receiveMirrorFile = receiveMirrorFile
-    self.sendFD = sendFD
-    self.sendMirrorFile = sendMirrorFile
-    self.messageRegistry = messageRegistry
-    globallyDisableSigpipeIfNeeded()
-  }
+  // MARK: - Static start
 
   #if os(macOS) || !canImport(Darwin)
   /// Creates and starts a `JSONRPCConnection` that connects to a subprocess launched with the specified arguments.
@@ -174,10 +129,11 @@ public final class JSONRPCConnection: Connection {
       // Keep the pipes alive until we close the connection.
       withExtendedLifetime((clientToServer, serverToClient)) {}
     }
-    let process = Foundation.Process()
+
     logger.log(
       "Launching JSON-RPC connection to \(executable.description) with options [\(arguments.joined(separator: " "))]"
     )
+    let process = Foundation.Process()
     process.executableURL = executable
     process.arguments = arguments
     process.standardOutput = serverToClient
@@ -219,76 +175,297 @@ public final class JSONRPCConnection: Connection {
 
     return (connection, process)
   }
-  #endif  // os(macOS) || !canImport(Darwin)
+  #endif
 
-  deinit {
-    assert(state == .closed)
-  }
+  // MARK: - Lifecycle
 
-  /// Change the handler that handles messages from the JSON-RPC connection to a new handler.
-  public func changeReceiveHandler(_ receiveHandler: MessageHandler) {
-    queue.sync {
-      self.receiveHandler = receiveHandler
+  public init(
+    name: String,
+    protocol messageRegistry: MessageRegistry,
+    receiveFD: FileHandle,
+    sendFD: FileHandle,
+    receiveMirrorFile: FileHandle? = nil,
+    sendMirrorFile: FileHandle? = nil
+  ) {
+    globallyDisableSigpipeIfNeeded()
+
+    self.name = name
+    self.receiveFD = receiveFD
+    self.sendFD = sendFD
+    self.receiveMirrorFile = receiveMirrorFile
+    self.sendMirrorFile = sendMirrorFile
+    self.messageRegistry = messageRegistry
+
+    // Create both streams before self is needed — continuations are let properties.
+    let (outgoingStream, outgoingCont) = AsyncStream<OutgoingItem>.makeStream()
+    let (sendStream, sendCont) = AsyncStream<Data>.makeStream()
+
+    self.outgoingContinuation = outgoingCont
+    self.sendContinuation = sendCont
+
+    // Task.detached so the blocking sendFD.write does not hold the actor's executor.
+    self.sendLoopTask = Task.detached {
+      for await data in sendStream {
+        orLog("Writing send mirror file") { try sendMirrorFile?.write(contentsOf: data) }
+        do {
+          try sendFD.write(contentsOf: data)
+        } catch {
+          logger.fault("IO error sending message to \(name): \(error.forLogging)")
+        }
+      }
+    }
+
+    // self is now fully initialized
+
+    // Fire-and-forget: processes outgoing items in FIFO order on the actor; when the outgoing
+    // stream ends (after _close drains it), calls sendContinuation.finish() so sendLoopTask exits.
+    // _close() awaits sendLoopTask.value, which transitively waits for this task to finish first.
+    Task {
+      for await item in outgoingStream {
+        await self.processOutgoing(item)
+      }
+      self.sendContinuation.finish()
     }
   }
 
-  /// Start processing `inFD` and send messages to `receiveHandler`.
+  /// Register the message handler and start the receive-path I/O.
   ///
-  /// - parameter receiveHandler: The message handler to invoke for requests received on the `inFD`.
-  ///
-  /// - Important: `start` must be called before sending any data over the `JSONRPCConnection`.
-  // Workaround formatter issue: https://github.com/swiftlang/swift-format/issues/1081
-  // swift-format-ignore
-  public func start(
+  /// - Important: Must be called before incoming messages can be dispatched.
+  public nonisolated func start(
     receiveHandler: MessageHandler,
     closeHandler: nonisolated(nonsending) @escaping @Sendable () async -> Void = {}
   ) {
-    queue.sync {
-      precondition(state == .created)
-      state = .running
-      self.receiveHandler = receiveHandler
-      self.closeHandler = closeHandler
-    }
+    Task { await self._start(receiveHandler: receiveHandler, closeHandler: closeHandler) }
+  }
 
-    self.receiveQueue.async {
-      let parser = JSONMessageParser(decoder: self.decodeJSONRPCMessage)
+  public nonisolated func changeReceiveHandler(_ receiveHandler: MessageHandler) {
+    Task { await self._changeReceiveHandler(receiveHandler) }
+  }
+
+  public nonisolated func close() {
+    Task { await self._close() }
+  }
+
+  // MARK: - Connection protocol (nonisolated — yields directly to the FIFO outgoing stream)
+
+  public nonisolated func send(_ notification: some NotificationType) {
+    outgoingContinuation.yield(.notification(notification))
+  }
+
+  public nonisolated func nextRequestID() -> RequestID {
+    return .string("sk-\(nextRequestIDStorage.fetchAndIncrement())")
+  }
+
+  public nonisolated func send<Request: RequestType>(
+    _ request: Request,
+    id: RequestID,
+    reply: @escaping @Sendable (LSPResult<Request.Response>) -> Void
+  ) {
+    let outstanding = OutstandingRequest(
+      requestMethod: Request.method,
+      responseType: Request.Response.self,
+      replyHandler: { anyResult in reply(anyResult.map { $0 as! Request.Response }) }
+    )
+    outgoingContinuation.yield(.request(request, id: id, outstanding: outstanding))
+  }
+
+  @_spi(Testing)
+  public nonisolated func sendReply(_ response: LSPResult<ResponseType>, id: RequestID) {
+    outgoingContinuation.yield(.reply(response, id: id))
+  }
+
+  @_spi(Testing)
+  public nonisolated func send(data: Data) {
+    outgoingContinuation.yield(.rawData(data))
+  }
+
+  // MARK: - Private actor-isolated implementation
+
+  private func _start(
+    receiveHandler: MessageHandler,
+    closeHandler: @escaping @Sendable () async -> Void
+  ) {
+    guard state == .running, self.receiveHandler == nil else { return }
+    self.receiveHandler = receiveHandler
+    self.closeHandler = closeHandler
+
+    // Receive stream: background task frames complete messages; actor decodes and dispatches.
+    let (receiveStream, receiveCont) = AsyncStream<Data>.makeStream()
+    let receiveFD = self.receiveFD
+    let receiveMirrorFile = self.receiveMirrorFile
+    let name = self.name
+    // Task.detached so the blocking receiveFD.read does not hold the actor's executor.
+    Task.detached {
+      let parser = JSONMessageParser<Data>(decoder: { $0 })
       while true {
-        let data = orLog("Reading from \(self.name)") { try self.receiveFD.read(upToCount: parser.nextReadLength) }
+        let data = orLog("Reading from \(name)") { try receiveFD.read(upToCount: parser.nextReadLength) }
         guard let data, !data.isEmpty else {
           // We have reached the end of `receiveFD`, close the connection.
-          self.close()
+          receiveCont.finish()
           return
         }
 
         orLog("Writing receive mirror file") {
-          try self.receiveMirrorFile?.write(contentsOf: data)
+          try receiveMirrorFile?.write(contentsOf: data)
         }
 
-        self.queue.sync {
-          if let message = parser.parse(chunk: data) {
-            self.handle(message)
-          }
+        if let messageBytes = parser.parse(chunk: data) {
+          receiveCont.yield(messageBytes)
         }
       }
     }
+
+    self.receiveLoopTask = Task {
+      for await messageBytes in receiveStream {
+        if let message = self.decodeJSONRPCMessage(messageBytes) {
+          self.handle(message)
+        }
+      }
+      await self._close()
+    }
   }
 
-  /// Send a notification to the client that informs the user about a message encoding or decoding error and asks them
-  /// to file an issue.
-  ///
-  /// `message` describes what has gone wrong to the user.
-  ///
-  /// - Important: Must be called on `queue`
-  private func sendMessageCodingErrorNotificationToClient(message: String) {
-    dispatchPrecondition(condition: .onQueue(queue))
+  private func _changeReceiveHandler(_ receiveHandler: MessageHandler) {
+    self.receiveHandler = receiveHandler
+  }
 
+  private func readyToSend(shouldLog: Bool = true) -> Bool {
+    let ready = state == .running || state == .closing
+    if shouldLog && !ready {
+      logger.error("Ignoring message; state = \(String(reflecting: self.state), privacy: .public)")
+    }
+    return ready
+  }
+
+  /// Process one outgoing work item. Called from `outgoingProcessorTask` (actor-isolated, FIFO).
+  private func processOutgoing(_ item: OutgoingItem) {
+    switch item {
+    case .notification(let notification):
+      logger.info(
+        """
+        Sending notification to \(self.name, privacy: .public)
+        \(notification.forLogging)
+        """
+      )
+      sendEncoded(.notification(notification))
+
+    case .request(let request, let id, let outstanding):
+      guard readyToSend() else {
+        outstanding.replyHandler(.failure(.serverCancelled))
+        return
+      }
+      logger.info(
+        """
+        Sending request to \(self.name, privacy: .public) (id: \(id, privacy: .public)):
+        \(request.forLogging)
+        """
+      )
+      // Register before bytes reach sendFD: the peer can only respond after receiving the bytes,
+      // so the response type is guaranteed to be registered before any response arrives.
+      outstandingRequests[id] = outstanding
+      sendEncoded(.request(request, id: id))
+
+    case .reply(let response, let id):
+      switch response {
+      case .success(let result): sendEncoded(.response(result, id: id))
+      case .failure(let error): sendEncoded(.errorResponse(error, id: id))
+      }
+
+    case .rawData(let data):
+      guard readyToSend() else { return }
+      sendContinuation.yield(data)
+    }
+  }
+
+  private func _close() async {
+    guard state == .running else { return }
+    state = .closing
+
+    logger.log("Closing JSONRPCConnection to \(self.name)")
+
+    // Finish the outgoing stream; the fire-and-forget processor will drain remaining items,
+    // then call sendContinuation.finish(). State is .closing so processOutgoing can still send.
+    outgoingContinuation.finish()
+
+    // Drain the send loop — waits transitively for the outgoing processor to finish first.
+    await sendLoopTask.value
+
+    state = .closed
+
+    // IMPORTANT: sendFD must be closed first; otherwise Windows blocks in receiveFD.close()
+    // waiting for the blocking read to return.
+    orLog("Closing sendFD to \(name)") { try sendFD.close() }
+    orLog("Closing receiveFD to \(name)") { try receiveFD.close() }
+    orLog("Closing sendMirrorFile to \(name)") { try sendMirrorFile?.close() }
+    orLog("Closing receiveMirrorFile to \(name)") { try receiveMirrorFile?.close() }
+
+    receiveLoopTask?.cancel()
+    receiveLoopTask = nil
+    receiveHandler = nil
+
+    for outstandingRequest in outstandingRequests.values {
+      outstandingRequest.replyHandler(.failure(ResponseError.serverCancelled))
+    }
+    outstandingRequests = [:]
+
+    await closeHandler?()
+  }
+
+  /// Handle received message.
+  private func handle(_ message: JSONRPCMessage) {
+    guard let receiveHandler, state != .closed else {
+      logger.error("Ignoring message as the JSON-RPC connection is closed: \(message.prettyPrintedRedactedJSON)")
+      return
+    }
+
+    switch message {
+    case .notification(let notification):
+      notification._handle(receiveHandler)
+    case .request(let request, let id):
+      request._handle(receiveHandler, id: id) { (response, id) in
+        self.sendReply(response, id: id)
+      }
+    case .response(let response, let id):
+      guard let outstanding = outstandingRequests.removeValue(forKey: id) else {
+        logger.error("No outstanding requests for response ID \(id, privacy: .public)")
+        return
+      }
+      logger.info(
+        """
+        Received reply for request \(id, privacy: .public) from \(self.name, privacy: .public)
+        \(outstanding.requestMethod, privacy: .public)
+        \(response.forLogging)
+        """
+      )
+      outstanding.replyHandler(.success(response))
+    case .errorResponse(let error, let id):
+      guard let id = id else {
+        logger.error("Received error response for unknown request: \(error.forLogging)")
+        return
+      }
+      guard let outstanding = outstandingRequests.removeValue(forKey: id) else {
+        logger.error("No outstanding requests for error response ID \(id, privacy: .public)")
+        return
+      }
+      logger.error(
+        """
+        Received error for request \(id, privacy: .public) from \(self.name, privacy: .public)
+        \(outstanding.requestMethod, privacy: .public)
+        \(error.forLogging)
+        """
+      )
+      outstanding.replyHandler(.failure(error))
+    }
+  }
+
+  private func sendMessageCodingErrorNotificationToClient(message: String) {
     let showMessage = ShowMessageNotification(
       type: .error,
       message: """
         \(message). Please run 'sourcekit-lsp diagnose' to file an issue.
         """
     )
-    self.sendAssumingOnQueue(.notification(showMessage))
+    sendEncoded(.notification(showMessage))
   }
 
   /// Decode a single JSONRPC message from the given `messageBytes`.
@@ -298,21 +475,17 @@ public final class JSONRPCConnection: Connection {
   ///
   /// If an error occurs during message parsing, this tries to recover as gracefully as possible and returns `nil`.
   /// Callers should consider the message handled and ignore it when this function returns `nil`.
-  ///
-  /// - Important: Must be called on `queue`
   private func decodeJSONRPCMessage(_ messageBytes: Data) -> JSONRPCMessage? {
-    dispatchPrecondition(condition: .onQueue(queue))
-
     let decoder = JSONDecoder()
 
     // Set message registry to use for model decoding.
     decoder.userInfo[.messageRegistryKey] = messageRegistry
 
-    // Setup callback for response type.
+    // Snapshot for the @Sendable decoder callback — safe because this method has no suspension
+    // points, so the snapshot is current for the entire synchronous decode call.
+    let localOutstandingRequests = outstandingRequests
     decoder.userInfo[.responseTypeCallbackKey] = { @Sendable (id: RequestID) -> ResponseType.Type? in
-      // `outstandingRequests` should never be mutated in this closure. Reading is fine as all of our other writes are
-      // guarded by `queue`, but `JSONDecoder` could (since this is sendable) invoke this concurrently.
-      guard let outstanding = self.outstandingRequests[id] else {
+      guard let outstanding = localOutstandingRequests[id] else {
         logger.error("Unknown request for \(id, privacy: .public)")
         return nil
       }
@@ -341,7 +514,7 @@ public final class JSONRPCConnection: Connection {
           logger.fault(
             "Replying to request \(id, privacy: .public) with error response because we failed to decode the request"
           )
-          self.sendAssumingOnQueue(.errorResponse(ResponseError(error), id: id))
+          sendEncoded(.errorResponse(ResponseError(error), id: id))
           return nil
         }
         // If we don't know the ID of the request, ignore it and show a notification to the user.
@@ -401,103 +574,9 @@ public final class JSONRPCConnection: Connection {
     }
   }
 
-  /// Whether we can send messages in the current state.
-  ///
-  /// - parameter shouldLog: Whether to log an info message if not ready.
-  ///
-  /// - Important: Must be called on `queue`. Note that the state might change as soon as execution leaves
-  ///  `queue`.
-  func readyToSend(shouldLog: Bool = true) -> Bool {
-    dispatchPrecondition(condition: .onQueue(queue))
-    precondition(state != .created, "tried to send message before calling start(messageHandler:)")
-
-    let ready = state == .running
-    if shouldLog && !ready {
-      logger.error("Ignoring message; state = \(String(reflecting: self.state), privacy: .public)")
-    }
-    return ready
-  }
-
-  /// Handle a single message by dispatching it to `receiveHandler` or an appropriate reply handler.
-  ///
-  /// - Important: Must be called on `queue`
-  func handle(_ message: JSONRPCMessage) {
-    dispatchPrecondition(condition: .onQueue(queue))
-
-    guard let receiveHandler, state == .running else {
-      logger.error("Ignoring message as the JSON-RPC connection is closed: \(message.prettyPrintedRedactedJSON)")
-      return
-    }
-
-    switch message {
-    case .notification(let notification):
-      notification._handle(receiveHandler)
-    case .request(let request, let id):
-      request._handle(receiveHandler, id: id) { (response, id) in
-        self.sendReply(response, id: id)
-      }
-    case .response(let response, let id):
-      guard let outstanding = outstandingRequests.removeValue(forKey: id) else {
-        logger.error("No outstanding requests for response ID \(id, privacy: .public)")
-        return
-      }
-      outstanding.replyHandler(.success(response))
-    case .errorResponse(let error, let id):
-      guard let id = id else {
-        logger.error("Received error response for unknown request: \(error.forLogging)")
-        return
-      }
-      guard let outstanding = outstandingRequests.removeValue(forKey: id) else {
-        logger.error("No outstanding requests for error response ID \(id, privacy: .public)")
-        return
-      }
-      outstanding.replyHandler(.failure(error))
-    }
-  }
-
-  /// Send the raw data to the receiving end of this connection.
-  ///
-  /// If an unrecoverable error occurred on the channel's file descriptor, the connection gets closed.
-  ///
-  /// - Important: Must be called on `queue`
-  private func sendAssumingOnQueue(data: Data) {
-    dispatchPrecondition(condition: .onQueue(queue))
-
+  /// Send outgoing message.
+  private func sendEncoded(_ message: JSONRPCMessage) {
     guard readyToSend() else { return }
-
-    sendQueue.async {
-      orLog("Writing send mirror file") {
-        try self.sendMirrorFile?.write(contentsOf: data)
-      }
-
-      do {
-        try self.sendFD.write(contentsOf: data)
-      } catch {
-        logger.fault("IO error sending message to \(self.name): \(error.forLogging)")
-        // This probably means the peer process exited unexpectedly.
-        // Nothing to do here. 'process.terminationHandler' should cleanup things.
-      }
-    }
-  }
-
-  /// Wrapper of `sendAssumingOnQueue(data:)` that automatically switches to `queue`.
-  ///
-  /// This should only be used to test that the client decodes messages correctly if data is delivered to it
-  /// byte-by-byte instead of in larger chunks that contain entire messages.
-  @_spi(Testing)
-  public func send(data: Data) {
-    queue.sync {
-      self.sendAssumingOnQueue(data: data)
-    }
-  }
-
-  /// Send the given message to the receiving end of the connection.
-  ///
-  /// If an unrecoverable error occurred on the channel's file descriptor, the connection gets closed.
-  ///
-  /// - Important: Must be called on `queue`
-  private func sendAssumingOnQueue(_ message: JSONRPCMessage) {
-    dispatchPrecondition(condition: .onQueue(queue))
 
     let content: Data
     do {
@@ -515,7 +594,7 @@ public final class JSONRPCConnection: Connection {
         )
         return
       case .request(_, _):
-        // We want to send a notification to the editor but failed to encode it. We don't know the `reply` handle for
+        // We want to send a request to the editor but failed to encode it. We don't know the `reply` handle for
         // the request at this point so we can't synthesize an errorResponse for the request. This means that the
         // request will never receive a reply. Inform the user about it.
         sendMessageCodingErrorNotificationToClient(
@@ -540,140 +619,7 @@ public final class JSONRPCConnection: Connection {
     }
 
     let header = "Content-Length: \(content.count)\r\n\r\n"
-    sendAssumingOnQueue(data: Data(header.utf8))
-    sendAssumingOnQueue(data: content)
-  }
-
-  /// Close the connection.
-  ///
-  /// The user-provided close handler will be called *asynchronously* when all outstanding I/O
-  /// operations have completed. No new I/O will be handled after `close` returns.
-  public func close() {
-    queue.sync {
-      closeAssumingOnQueue()
-    }
-  }
-
-  /// Close the connection, assuming that the code is already executing on `queue`.
-  ///
-  /// - Important: Must be called on `queue`.
-  private func closeAssumingOnQueue() {
-    dispatchPrecondition(condition: .onQueue(queue))
-
-    guard state == .running else { return }
-    state = .closed
-
-    logger.log("Closing JSONRPCConnection to \(self.name)")
-
-    // Allow any data in queue to be sent before closing
-    sendQueue.sync {
-      // IMPORTANT: `sendFD` *must* be closed first so that the corresponding process sends an EOF to `receiveFD`,
-      // otherwise Windows will wait in `receiveFD.close` for the `receiveFD.read` on the read loop thread to return.
-      // macOS/Linux both return from the read with a `EPIPE` regardless, so the order doesn't matter there.
-      orLog("Closing sendFD to \(name)") {
-        try sendFD.close()
-      }
-      orLog("Closing receiveFD to \(name)") {
-        try receiveFD.close()
-      }
-      orLog("Closing sendMirrorFile to \(name)") {
-        try sendMirrorFile?.close()
-      }
-      orLog("Closing receiveMirrorFile to \(name)") {
-        try receiveMirrorFile?.close()
-      }
-    }
-
-    self.receiveHandler = nil
-    for outstandingRequest in self.outstandingRequests.values {
-      outstandingRequest.replyHandler(LSPResult.failure(ResponseError.internalError("JSON-RPC connection closed")))
-    }
-    self.outstandingRequests = [:]
-
-    Task {
-      await self.closeHandler?()
-    }
-  }
-
-  /// Request id for the next outgoing request.
-  public func nextRequestID() -> RequestID {
-    return .string("sk-\(nextRequestIDStorage.fetchAndIncrement())")
-  }
-
-  // MARK: Connection interface
-
-  /// Send the notification to the remote side of the notification.
-  public func send(_ notification: some NotificationType) {
-    queue.async {
-      logger.info(
-        """
-        Sending notification to \(self.name, privacy: .public)
-        \(notification.forLogging)
-        """
-      )
-      self.sendAssumingOnQueue(.notification(notification))
-    }
-  }
-
-  /// Send the given request to the remote side of the connection.
-  ///
-  /// When the receiving end replies to the request, execute `reply` with the response.
-  public func send<Request: RequestType>(
-    _ request: Request,
-    id: RequestID,
-    reply: @escaping @Sendable (LSPResult<Request.Response>) -> Void
-  ) {
-    self.queue.async {
-      guard self.readyToSend() else {
-        reply(.failure(.serverCancelled))
-        return
-      }
-
-      self.outstandingRequests[id] = OutstandingRequest(
-        responseType: Request.Response.self,
-        replyHandler: { anyResult in
-          let result = anyResult.map { $0 as! Request.Response }
-          switch result {
-          case .success(let response):
-            logger.info(
-              """
-              Received reply for request \(id, privacy: .public) from \(self.name, privacy: .public)
-              \(Request.method, privacy: .public)
-              \(response.forLogging)
-              """
-            )
-          case .failure(let error):
-            logger.error(
-              """
-              Received error for request \(id, privacy: .public) from \(self.name, privacy: .public)
-              \(Request.method, privacy: .public)
-              \(error.forLogging)
-              """
-            )
-          }
-          reply(result)
-        }
-      )
-      logger.info(
-        """
-        Sending request to \(self.name, privacy: .public) (id: \(id, privacy: .public)):
-        \(request.forLogging)
-        """
-      )
-
-      self.sendAssumingOnQueue(.request(request, id: id))
-    }
-  }
-
-  /// After the remote side of the connection sent a request to us, return a reply to the remote side.
-  public func sendReply(_ response: LSPResult<ResponseType>, id: RequestID) {
-    queue.async {
-      switch response {
-      case .success(let result):
-        self.sendAssumingOnQueue(.response(result, id: id))
-      case .failure(let error):
-        self.sendAssumingOnQueue(.errorResponse(error, id: id))
-      }
-    }
+    sendContinuation.yield(Data(header.utf8))
+    sendContinuation.yield(content)
   }
 }

--- a/Tests/LanguageServerProtocolTransportTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTransportTests/ConnectionTests.swift
@@ -296,7 +296,7 @@ class ConnectionTests: XCTestCase {
         "params": {}
       }
       """
-    connection.clientToServerConnection.send(message: messageContents)
+    await connection.clientToServerConnection.send(message: messageContents)
 
     try await fulfillmentOfOrThrow(expectation)
   }


### PR DESCRIPTION
Experimenting.

Three `AsyncStream`s.

**`AsyncStream<OutgoingItem>` (outgoingContinuation)**
Serializes all outgoing work items (notifications, requests, replies) from any caller into the actor. Its `Continuation` is a `let` property, making `send`/`sendReply` fully `nonisolated` — callers never have to hop to the actor just to enqueue a message. The fire-and-forget actor task drains it in strict FIFO order, guaranteeing message ordering without a dispatch queue.

**`AsyncStream<Data>` (sendContinuation)**
Decouples the actor-isolated encoding step from the blocking `sendFD.write`. The actor encodes a message and yields the bytes synchronously; the `Task.detached` send loop picks them up and blocks the thread waiting on I/O, without ever touching the actor. This is why two "send" streams are needed rather than one: the blocking write must not hold the actor's executor.

**`AsyncStream<Data>` (receiveStream, created in `_start`)**
Same idea on the read side. The `Task.detached` reader blocks on `receiveFD.read`, yields complete framed messages, and the actor-isolated `receiveLoopTask` picks them up to decode and dispatch. The stream is the hand-off point between the blocking I/O thread and the actor.