### PR TITLE
Refactor AsyncQueue: replace-on-insert + symmetric async/asyncThrowing

### DIFF
--- a/Sources/ToolsProtocolsSwiftExtensions/AsyncQueue.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/AsyncQueue.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -17,13 +17,11 @@ import Synchronization
 /// array.
 private protocol AnyTask: Sendable {
   func waitForCompletion() async
-
-  func cancel()
 }
 
 extension Task: AnyTask {
   func waitForCompletion() async {
-    _ = try? await value
+    _ = await result
   }
 }
 
@@ -41,122 +39,127 @@ public struct Serial: DependencyTracker {
   }
 }
 
-package struct PendingTask<TaskMetadata: Sendable & Hashable>: Sendable {
-  /// The task that is pending.
-  fileprivate let task: any AnyTask
+private struct RegisteredTask: Sendable {
+  let task: any AnyTask
 
   /// A unique value used to identify the task. This allows tasks to get
-  /// removed from `pendingTasks` again after they finished executing.
-  fileprivate let id: UUID
+  /// removed from `dependencyCandidates` again after they finished executing.
+  let id: UUID
 }
 
-/// A queue that allows the execution of asynchronous blocks of code.
+/// Schedules async tasks with metadata-driven dependency ordering.
+///
+/// Each submitted task carries a ``DependencyTracker`` metadata value. Before a
+/// new task executes, the queue waits for any already-pending tasks whose
+/// metadata satisfies `isDependency(of:)` for the new task's metadata. Tasks
+/// with no dependency relationship run concurrently.
+///
+/// `AsyncQueue<Serial>` makes every task depend on all others, producing a
+/// classic serial FIFO queue.
 public final class AsyncQueue<TaskMetadata: DependencyTracker>: Sendable {
-  /// Pending tasks that have not finished execution yet, guarded by a mutex.
-  private let pendingTasks = Mutex<[TaskMetadata: [PendingTask<TaskMetadata>]]>([:])
+  /// Tasks visible to future schedulings as potential dependencies.
+  ///
+  /// - For self-serializing metadata, only the latest task is stored - earlier in-flight
+  ///   tasks were removed on insert because the latest transitively depends on them, so
+  ///   future schedulings only need to wait on the latest.
+  /// - For non-self-serializing metadata, all in-flight tasks are stored.
+  ///
+  /// The retain cycle (AsyncQueue -> dependencyCandidates -> Task -> self) is intentional.
+  /// It keeps the queue alive until all tasks complete so their cleanup always runs.
+  /// Each task breaks the cycle on exit.
+  private let dependencyCandidates = Mutex<[TaskMetadata: [RegisteredTask]]>([:])
 
   public init() {}
 
-  /// Schedule a new closure to be executed on the queue.
+  /// Schedule `operation` to run on the queue.
   ///
-  /// If this is a serial queue, all previously added tasks are guaranteed to
-  /// finished executing before this closure gets executed.
-  ///
-  /// If this is a barrier, all previously scheduled tasks are guaranteed to
-  /// finish execution before the barrier is executed and all tasks that are
-  /// added later will wait until the barrier finishes execution.
-  // Workaround formatter issue: https://github.com/swiftlang/swift-format/issues/1081
-  // swift-format-ignore
+  /// The operation begins after all already-scheduled tasks whose metadata is a
+  /// dependency of `metadata` have completed.
   @discardableResult
   public func async<Success: Sendable>(
     priority: TaskPriority? = nil,
     metadata: TaskMetadata,
     @_inheritActorContext operation: nonisolated(nonsending) @escaping @Sendable () async -> Success
   ) -> Task<Success, Never> {
-    let throwingTask = asyncThrowing(priority: priority, metadata: metadata, operation: operation)
-    return Task(priority: priority) {
-      do {
-        return try await throwingTask.valuePropagatingCancellation
-      } catch {
-        // We know this can never happen because `operation` does not throw.
-        preconditionFailure("Executing a task threw an error even though the operation did not throw")
+    self.registerTask(for: metadata) { id, deps in
+      Task(priority: priority) {
+        await self.runRegistered(id: id, for: metadata, awaiting: deps, body: operation)
       }
     }
   }
 
-  /// Same as ``AsyncQueue/async(priority:barrier:operation:)`` but allows the
+  /// Same as ``AsyncQueue/async(priority:metadata:operation:)`` but allows the
   /// operation to throw.
   ///
   /// - Important: The caller is responsible for handling any errors thrown from
   ///   the operation by awaiting the result of the returned task.
-  // Workaround formatter issue: https://github.com/swiftlang/swift-format/issues/1081
-  // swift-format-ignore
   public func asyncThrowing<Success: Sendable>(
     priority: TaskPriority? = nil,
     metadata: TaskMetadata,
     @_inheritActorContext operation: nonisolated(nonsending) @escaping @Sendable () async throws -> Success
   ) -> Task<Success, any Error> {
-    let id = UUID()
+    self.registerTask(for: metadata) { id, deps in
+      Task(priority: priority) {
+        try await self.runRegistered(id: id, for: metadata, awaiting: deps, body: operation)
+      }
+    }
+  }
 
-    return pendingTasks.withLock { tasksByMetadata in
-      // Build the list of tasks that need to finished execution before this one
-      // can be executed
-      var dependencies: [PendingTask<TaskMetadata>] = []
-      for (pendingMetadata, pendingTasks) in tasksByMetadata {
-        guard pendingMetadata.isDependency(of: metadata) else {
-          // No dependency
-          continue
-        }
-        if pendingMetadata.isDependency(of: pendingMetadata), let lastPendingTask = pendingTasks.last {
-          // This kind of task depends on all other tasks of the same kind finishing. It is sufficient to just wait on
-          // the last task with this metadata, it will have all the other tasks with the same metadata as transitive
-          // dependencies.
-          dependencies.append(lastPendingTask)
-        } else {
-          // We depend on tasks with this metadata, but they don't have any dependencies between them, eg.
-          // `documentUpdate` depends on all `documentRequest` but `documentRequest` don't have dependencies between
-          // them. We need to depend on all of them unless we knew that we depended on some other task that already
-          // depends on all of these. But determining that would also require knowledge about the entire dependency
-          // graph, which is likely as expensive as depending on all of these tasks.
-          dependencies += pendingTasks
-        }
+  /// Atomically computes the dependencies for a new task with `metadata`, lets `makeTask`
+  /// build the Task using those, and registers it as a dependency candidate.
+  private func registerTask<T: AnyTask>(
+    for metadata: TaskMetadata,
+    _ makeTask: (_ newTaskId: UUID, _ dependencies: [RegisteredTask]) -> T
+  ) -> T {
+    dependencyCandidates.withLock { candidates in
+      let id = UUID()
+
+      // Tasks that must finish before this one can execute.
+      let dependencies: [RegisteredTask] = candidates.flatMap { candidateMetadata, tasks in
+        candidateMetadata.isDependency(of: metadata) ? tasks : []
       }
 
-      // Schedule the task.
-      let task = Task(priority: priority) {
-        // IMPORTANT: The only throwing call in here must be the call to
-        // operation. Otherwise the assumption that the task will never throw
-        // if `operation` does not throw, which we are making in `async` does
-        // not hold anymore.
-        defer {
-          self.pendingTasks.withLock { tasksByMetadata in
-            tasksByMetadata[metadata, default: []].removeAll(where: { $0.id == id })
-            if tasksByMetadata[metadata]?.isEmpty ?? false {
-              tasksByMetadata[metadata] = nil
-            }
-          }
-        }
+      let task = makeTask(id, dependencies)
 
-        await dependencies.concurrentForEach { dependency in
-          await dependency.task.waitForCompletion()
-        }
-
-        return try await operation()
+      // Register the task as a dependency candidate.
+      if metadata.isDependency(of: metadata) {
+        // For self-serializing metadata, only the latest task matters as a dependency,
+        // it transitively covers all previous ones. Replace rather than append.
+        candidates[metadata] = [RegisteredTask(task: task, id: id)]
+      } else {
+        candidates[metadata, default: []].append(RegisteredTask(task: task, id: id))
       }
-
-      tasksByMetadata[metadata, default: []].append(PendingTask(task: task, id: id))
-
       return task
     }
+  }
+
+  /// Run `operation` after `dependencies` complete, removing this task from the queue on exit.
+  private func runRegistered<Success: Sendable>(
+    id: UUID,
+    for metadata: TaskMetadata,
+    awaiting dependencies: [RegisteredTask],
+    body operation: () async throws -> Success
+  ) async rethrows -> Success {
+    defer {
+      self.dependencyCandidates.withLock { candidates in
+        guard var bucket = candidates[metadata] else { return }
+        bucket.removeAll { $0.id == id }
+        candidates[metadata] = bucket.isEmpty ? nil : bucket
+      }
+    }
+    // Await all dependencies concurrently so that a priority escalation on this task
+    // propagates to every dependency at once, not just to the one currently being awaited.
+    await dependencies.concurrentForEach { dependency in
+      await dependency.task.waitForCompletion()
+    }
+    return try await operation()
   }
 }
 
 /// Convenience overloads for serial queues.
 extension AsyncQueue where TaskMetadata == Serial {
-  /// Same as ``async(priority:operation:)`` but specialized for serial queues
-  /// that don't specify any metadata.
-  // Workaround formatter issue: https://github.com/swiftlang/swift-format/issues/1081
-  // swift-format-ignore
+  /// Same as ``async(priority:metadata:operation:)`` but specialized for serial
+  /// queues that don't specify any metadata.
   @discardableResult
   public func async<Success: Sendable>(
     priority: TaskPriority? = nil,
@@ -167,8 +170,6 @@ extension AsyncQueue where TaskMetadata == Serial {
 
   /// Same as ``asyncThrowing(priority:metadata:operation:)`` but specialized
   /// for serial queues that don't specify any metadata.
-  // Workaround formatter issue: https://github.com/swiftlang/swift-format/issues/1081
-  // swift-format-ignore
   public func asyncThrowing<Success: Sendable>(
     priority: TaskPriority? = nil,
     @_inheritActorContext operation: nonisolated(nonsending) @escaping @Sendable () async throws -> Success

--- a/Sources/ToolsProtocolsSwiftExtensions/AsyncUtils.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/AsyncUtils.swift
@@ -175,7 +175,7 @@ extension Collection where Self: Sendable, Element: Sendable {
   // Workaround formatter issue: https://github.com/swiftlang/swift-format/issues/1081
   // swift-format-ignore
   @_spi(SourceKitLSP) public func concurrentForEach(_ body: nonisolated(nonsending) @escaping @Sendable (Element) async -> Void) async {
-    await withTaskGroup(of: Void.self) { taskGroup in
+    await withDiscardingTaskGroup { taskGroup in
       for element in self {
         taskGroup.addTask {
           await body(element)

--- a/Tests/ToolsProtocolsSwiftExtensionsTests/AsyncQueueTests.swift
+++ b/Tests/ToolsProtocolsSwiftExtensionsTests/AsyncQueueTests.swift
@@ -37,6 +37,60 @@ struct AsyncQueueTests {
     }
   }
 
+  /// `AsyncQueue<Serial>` runs tasks in the order they were scheduled.
+  @Test func serialTasks() async throws {
+    let queue = AsyncQueue<Serial>()
+    let recorded = ThreadSafeBox<[Int]>(initialValue: [])
+    let count = 5
+
+    var lastTask: Task<Void, Never>?
+    for i in 0..<count {
+      lastTask = queue.async {
+        recorded.withLock { $0.append(i) }
+      }
+    }
+    await lastTask?.value
+    #expect(recorded.value == Array(0..<count))
+  }
+
+  /// Tasks whose metadata has no dependency relationship with each other run
+  /// concurrently — not serially.
+  @Test func concurrentTasks() async throws {
+    let queue = AsyncQueue<Meta>()
+    let count = 5
+
+    let (startedStream, startedCont) = AsyncStream<Void>.makeStream()
+    let (releaseStream, releaseCont) = AsyncStream<Void>.makeStream()
+    // A single consumer drives the release stream; each task awaits this Task's
+    // value so multiple waiters all unblock when the stream finishes.
+    let releaseTask = Task<Void, Never> { for await _ in releaseStream {} }
+
+    var tasks: [Task<Void, Never>] = []
+    for _ in 0..<count {
+      let task = queue.async(metadata: .concurrent) {
+        startedCont.yield()
+        _ = await releaseTask.value
+      }
+      tasks.append(task)
+    }
+
+    // Each task signals before awaiting release. If the queue ran them
+    // serially, only one would signal and the started-stream loop would block
+    // indefinitely. `withTimeout` turns that into a fast, labeled failure.
+    let scheduledTasks = tasks
+    try await withTimeout(.seconds(5)) {
+      var startedCount = 0
+      for await _ in startedStream {
+        startedCount += 1
+        if startedCount == count { break }
+      }
+      releaseCont.finish()
+      for task in scheduledTasks {
+        await task.value
+      }
+    }
+  }
+
   /// A task depending on a non-self-serializing bucket must wait on every
   /// task in that bucket, not just the last one.
   @Test func serialTaskWaitsForAllConcurrentDependencies() async throws {


### PR DESCRIPTION
Refactor `AsyncQueue` and also some doc-comment improvements and test case additions.
No observable behavior change intended.

### Replace-on-insert for self-serializing metadata

Simplifies overall dependency tracking: if a metadata is self-serializing, a new task only needs to depend on the last entry (it transitively covers earlier ones), so we only need to remember the last one. Replace rather than append on insert, and the read path becomes a single `reduce(into:)` collecting tasks from buckets whose metadata is a dependency.

Renames to reflect the new semantics:
- `pendingTasks` → `dependencyCandidates` (no longer holds *all* in-flight tasks; only those visible to future schedulings)
- `PendingTask` → `RegisteredTask` (also dropped its generic parameter and made it `private`)

### Symmetric `async()` and `asyncThrowing()`

Previously the non-throwing `async` was implemented by wrapping `asyncThrowing`'s `Task<_, any Error>` in a second `Task<_, Never>` with a `preconditionFailure` in the catch. Two Tasks per call, plus a "the only throwing call here must be `operation`" invariant the compiler couldn't enforce.

Now both share the same scaffolding via two helpers:
- `withDependencies(for:_:)`: atomically computes dependencies and registers a caller-built Task in a single lock scope. Generic over `T: AnyTask`, so it returns the same Task type the body produces.
- `runRegistered`: waits for dependencies, runs the operation, removes the task on exit. Uses `rethrows` to propagate throwing-ness from the operation closure.

Now `async` and `asyncThrowing` now have parallel structure that differs only in `try`. The `rethrows` contract enforces the no-other-throws invariant for free.
