### PR TITLE
[6.4] Fix RegistrationOptions encoding to correctly merge objects

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/LSPAny+Coding.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/LSPAny+Coding.swift
@@ -80,7 +80,14 @@ private final class LSPAnyEncoder: Encoder {
     // MARK: - .keyed
 
     func prepareKeyed() {
-      storage = .keyed([:])
+      switch storage {
+      case nil:
+        storage = .keyed([:])
+      case .keyed?:
+        break
+      case .single?, .unkeyed?:
+        preconditionFailure("cannot create keyed container after encoding a non-keyed value")
+      }
     }
     func set(key: String, value: LSPAnyReference) {
       guard case .keyed(var dictionary)? = storage else {
@@ -94,7 +101,14 @@ private final class LSPAnyEncoder: Encoder {
     // MARK: - .unkeyed
 
     func prepareUnkeyed() {
-      storage = .unkeyed([])
+      switch storage {
+      case nil:
+        storage = .unkeyed([])
+      case .unkeyed?:
+        break
+      case .single?, .keyed?:
+        preconditionFailure("cannot create unkeyed container after encoding a non-unkeyed value")
+      }
     }
     func append(value: LSPAnyReference) {
       guard case .unkeyed(var array)? = storage else {

--- a/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
@@ -34,7 +34,7 @@ public protocol TextDocumentRegistrationOptionsProtocol {
   var textDocumentRegistrationOptions: TextDocumentRegistrationOptions { get }
 }
 
-/// Code completiion registration options.
+/// Code completion registration options.
 public struct CompletionRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol, Hashable {
   public var textDocumentRegistrationOptions: TextDocumentRegistrationOptions
   public var completionOptions: CompletionOptions
@@ -43,6 +43,16 @@ public struct CompletionRegistrationOptions: RegistrationOptions, TextDocumentRe
     self.textDocumentRegistrationOptions =
       TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.completionOptions = completionOptions
+  }
+
+  public init(from decoder: Decoder) throws {
+    self.textDocumentRegistrationOptions = try TextDocumentRegistrationOptions(from: decoder)
+    self.completionOptions = try CompletionOptions(from: decoder)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try textDocumentRegistrationOptions.encode(to: encoder)
+    try completionOptions.encode(to: encoder)
   }
 }
 
@@ -56,6 +66,16 @@ public struct SignatureHelpRegistrationOptions: RegistrationOptions, TextDocumen
       TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.signatureHelpOptions = signatureHelpOptions
   }
+
+  public init(from decoder: Decoder) throws {
+    self.textDocumentRegistrationOptions = try TextDocumentRegistrationOptions(from: decoder)
+    self.signatureHelpOptions = try SignatureHelpOptions(from: decoder)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try textDocumentRegistrationOptions.encode(to: encoder)
+    try signatureHelpOptions.encode(to: encoder)
+  }
 }
 
 /// Folding range registration options.
@@ -67,6 +87,16 @@ public struct FoldingRangeRegistrationOptions: RegistrationOptions, TextDocument
     self.textDocumentRegistrationOptions =
       TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.foldingRangeOptions = foldingRangeOptions
+  }
+
+  public init(from decoder: Decoder) throws {
+    self.textDocumentRegistrationOptions = try TextDocumentRegistrationOptions(from: decoder)
+    self.foldingRangeOptions = try FoldingRangeOptions(from: decoder)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try textDocumentRegistrationOptions.encode(to: encoder)
+    try foldingRangeOptions.encode(to: encoder)
   }
 }
 
@@ -84,6 +114,16 @@ public struct SemanticTokensRegistrationOptions: RegistrationOptions, TextDocume
       TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.semanticTokenOptions = semanticTokenOptions
   }
+
+  public init(from decoder: Decoder) throws {
+    self.textDocumentRegistrationOptions = try TextDocumentRegistrationOptions(from: decoder)
+    self.semanticTokenOptions = try SemanticTokensOptions(from: decoder)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try textDocumentRegistrationOptions.encode(to: encoder)
+    try semanticTokenOptions.encode(to: encoder)
+  }
 }
 
 public struct InlayHintRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol, Hashable {
@@ -96,6 +136,16 @@ public struct InlayHintRegistrationOptions: RegistrationOptions, TextDocumentReg
   ) {
     textDocumentRegistrationOptions = TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.inlayHintOptions = inlayHintOptions
+  }
+
+  public init(from decoder: Decoder) throws {
+    self.textDocumentRegistrationOptions = try TextDocumentRegistrationOptions(from: decoder)
+    self.inlayHintOptions = try InlayHintOptions(from: decoder)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try textDocumentRegistrationOptions.encode(to: encoder)
+    try inlayHintOptions.encode(to: encoder)
   }
 }
 
@@ -111,6 +161,16 @@ public struct DiagnosticRegistrationOptions: RegistrationOptions, TextDocumentRe
     textDocumentRegistrationOptions = TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.diagnosticOptions = diagnosticOptions
   }
+
+  public init(from decoder: Decoder) throws {
+    self.textDocumentRegistrationOptions = try TextDocumentRegistrationOptions(from: decoder)
+    self.diagnosticOptions = try DiagnosticOptions(from: decoder)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try textDocumentRegistrationOptions.encode(to: encoder)
+    try diagnosticOptions.encode(to: encoder)
+  }
 }
 
 /// Describe options to be used when registering for code lenses.
@@ -124,6 +184,16 @@ public struct CodeLensRegistrationOptions: RegistrationOptions, TextDocumentRegi
   ) {
     textDocumentRegistrationOptions = TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.codeLensOptions = codeLensOptions
+  }
+
+  public init(from decoder: Decoder) throws {
+    self.textDocumentRegistrationOptions = try TextDocumentRegistrationOptions(from: decoder)
+    self.codeLensOptions = try CodeLensOptions(from: decoder)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try textDocumentRegistrationOptions.encode(to: encoder)
+    try codeLensOptions.encode(to: encoder)
   }
 }
 

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -1392,6 +1392,261 @@ final class CodingTests: XCTestCase {
   func testShutdownResponse() {
     checkCoding(ShutdownRequest.Response(), json: "null")
   }
+
+  func testRegistrationOptions() {
+    // Include the actual CapabilityRegistration here to ensure LSPAny encoding can merge the options correctly
+    checkCoding(
+      CapabilityRegistration(
+        id: "registration-id",
+        method: "test/method",
+        registerOptions: CompletionRegistrationOptions(
+          documentSelector: [DocumentFilter(language: "swift")],
+          completionOptions: CompletionOptions(resolveProvider: true, triggerCharacters: [".", "("])
+        ).encodeToLSPAny()
+      ),
+      json: """
+        {
+          "id" : "registration-id",
+          "method" : "test/method",
+          "registerOptions" : {
+            "documentSelector" : [
+              {
+                "language" : "swift"
+              }
+            ],
+            "resolveProvider" : true,
+            "triggerCharacters" : [
+              ".",
+              "("
+            ]
+          }
+        }
+        """
+    )
+
+    checkCoding(
+      CapabilityRegistration(
+        id: "registration-id",
+        method: "test/method",
+        registerOptions: SignatureHelpRegistrationOptions(
+          documentSelector: [DocumentFilter(language: "swift")],
+          signatureHelpOptions: SignatureHelpOptions(triggerCharacters: ["(", "["], retriggerCharacters: [",", ":"])
+        ).encodeToLSPAny()
+      ),
+      json: """
+        {
+          "id" : "registration-id",
+          "method" : "test/method",
+          "registerOptions" : {
+            "documentSelector" : [
+              {
+                "language" : "swift"
+              }
+            ],
+            "retriggerCharacters" : [
+              ",",
+              ":"
+            ],
+            "triggerCharacters" : [
+              "(",
+              "["
+            ]
+          }
+        }
+        """
+    )
+
+    checkCoding(
+      CapabilityRegistration(
+        id: "registration-id",
+        method: "test/method",
+        registerOptions:
+          FoldingRangeRegistrationOptions(
+            documentSelector: [DocumentFilter(language: "swift")],
+            foldingRangeOptions: FoldingRangeOptions()
+          ).encodeToLSPAny()
+      ),
+      json: """
+        {
+          "id" : "registration-id",
+          "method" : "test/method",
+          "registerOptions" : {
+            "documentSelector" : [
+              {
+                "language" : "swift"
+              }
+            ]
+          }
+        }
+        """
+    )
+
+    checkCoding(
+      CapabilityRegistration(
+        id: "registration-id",
+        method: "test/method",
+        registerOptions:
+          SemanticTokensRegistrationOptions(
+            documentSelector: [DocumentFilter(language: "swift")],
+            semanticTokenOptions: SemanticTokensOptions(
+              legend: SemanticTokensLegend(
+                tokenTypes: ["class", "function"],
+                tokenModifiers: ["declaration", "static"]
+              ),
+              range: .bool(true),
+              full: .bool(true)
+            )
+          ).encodeToLSPAny()
+      ),
+      json: """
+        {
+          "id" : "registration-id",
+          "method" : "test/method",
+          "registerOptions" : {
+            "documentSelector" : [
+              {
+                "language" : "swift"
+              }
+            ],
+            "full" : true,
+            "legend" : {
+              "tokenModifiers" : [
+                "declaration",
+                "static"
+              ],
+              "tokenTypes" : [
+                "class",
+                "function"
+              ]
+            },
+            "range" : true
+          }
+        }
+        """
+    )
+
+    checkCoding(
+      CapabilityRegistration(
+        id: "registration-id",
+        method: "test/method",
+        registerOptions:
+          InlayHintRegistrationOptions(
+            documentSelector: [DocumentFilter(language: "swift")],
+            inlayHintOptions: InlayHintOptions(resolveProvider: true)
+          ).encodeToLSPAny()
+      ),
+      json: """
+        {
+          "id" : "registration-id",
+          "method" : "test/method",
+          "registerOptions" : {
+            "documentSelector" : [
+              {
+                "language" : "swift"
+              }
+            ],
+            "resolveProvider" : true
+          }
+        }
+        """
+    )
+
+    checkCoding(
+      CapabilityRegistration(
+        id: "registration-id",
+        method: "test/method",
+        registerOptions:
+          DiagnosticRegistrationOptions(
+            documentSelector: [DocumentFilter(language: "swift")],
+            diagnosticOptions: DiagnosticOptions(interFileDependencies: true, workspaceDiagnostics: false)
+          ).encodeToLSPAny()
+      ),
+      json: """
+        {
+          "id" : "registration-id",
+          "method" : "test/method",
+          "registerOptions" : {
+            "documentSelector" : [
+              {
+                "language" : "swift"
+              }
+            ],
+            "interFileDependencies" : true,
+            "workspaceDiagnostics" : false
+          }
+        }
+        """
+    )
+
+    checkCoding(
+      CapabilityRegistration(
+        id: "registration-id",
+        method: "test/method",
+        registerOptions:
+          CodeLensRegistrationOptions(
+            documentSelector: [DocumentFilter(language: "swift")],
+            codeLensOptions: CodeLensOptions(resolveProvider: true)
+          ).encodeToLSPAny()
+      ),
+      json: """
+        {
+          "id" : "registration-id",
+          "method" : "test/method",
+          "registerOptions" : {
+            "documentSelector" : [
+              {
+                "language" : "swift"
+              }
+            ],
+            "resolveProvider" : true
+          }
+        }
+        """
+    )
+
+    checkCoding(
+      CapabilityRegistration(
+        id: "registration-id",
+        method: "test/method",
+        registerOptions:
+          DidChangeWatchedFilesRegistrationOptions(watchers: [FileSystemWatcher(globPattern: "**/*.swift")])
+          .encodeToLSPAny()
+      ),
+      json: """
+        {
+          "id" : "registration-id",
+          "method" : "test/method",
+          "registerOptions" : {
+            "watchers" : [
+              {
+                "globPattern" : "**/*.swift"
+              }
+            ]
+          }
+        }
+        """
+    )
+
+    checkCoding(
+      CapabilityRegistration(
+        id: "registration-id",
+        method: "test/method",
+        registerOptions:
+          ExecuteCommandRegistrationOptions(commands: ["sourcekit-lsp.test"]).encodeToLSPAny()
+      ),
+      json: """
+        {
+          "id" : "registration-id",
+          "method" : "test/method",
+          "registerOptions" : {
+            "commands" : [
+              "sourcekit-lsp.test"
+            ]
+          }
+        }
+        """
+    )
+  }
 }
 
 func with<T>(_ value: T, mutate: (inout T) -> Void) -> T {


### PR DESCRIPTION
- **Explanation**: Fixes a wrong encoding/decoding behavior of `RegistrationOptions` that was previously introduced. The correct behavior is to merge the two objects into one instead of having two fields, each containing one of the objects.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: `RegistrationOptions`, used when sending the `client/registerCapability` request
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: -
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: #55 
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Only affects the types used for the `client/registerCapability` request
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Added additional test cases that cover the changes and prevent future regressions
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: Alex Hoppen (@ahoppen), Rintaro Ishizaki (@rintaro)
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->