### PR TITLE
AsyncQueue: await dependencies concurrently to avoid priority inversion

### DIFF
--- a/Sources/ToolsProtocolsSwiftExtensions/AsyncQueue.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/AsyncQueue.swift
@@ -137,7 +137,7 @@ public final class AsyncQueue<TaskMetadata: DependencyTracker>: Sendable {
           }
         }
 
-        for dependency in dependencies {
+        await dependencies.concurrentForEach { dependency in
           await dependency.task.waitForCompletion()
         }
 


### PR DESCRIPTION
A sequentially-awaited list of dependency tasks only propagates a priority escalation to the dependency currently being awaited. The rest stay at their original priority and can starve under load, producing nondeterministic multi-minute hangs in tests that mix self-serializing and non-self-serializing metadata (e.g. a serial task waiting on many concurrent tasks).

Replace the sequential await with `concurrentForEach` so a priority escalation on the running task reaches every dependency at once.

Speculative fix for rdar://178006261