### PR TITLE
[6.4] AsyncQueue: await dependencies concurrently to avoid priority inversion

### DIFF
--- a/Sources/ToolsProtocolsSwiftExtensions/AsyncQueue.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/AsyncQueue.swift
@@ -161,7 +161,7 @@ public final class AsyncQueue<TaskMetadata: DependencyTracker>: Sendable {
           }
         }
 
-        for dependency in dependencies {
+        await dependencies.concurrentForEach { dependency in
           await dependency.task.waitForCompletion()
         }
 


### PR DESCRIPTION
Cherry-pick #57 into `release/6.4.x`

- **Explanation**: Replaces the sequential `for ... await dep.task.waitForCompletion()` loop in `AsyncQueue.swift` with `dependencies.concurrentForEach { ... }`. Functionally equivalent for the dependency tasks themselves (which already run concurrently), but the *await* fan-out changes so that a priority escalation on the awaiting task propagates to every dependency at once instead of only the one currently being awaited.
- **Scope**: AsyncQueue
- **Issues**: rdar://178006261
- **Risk**: Low. The change is semantically equivalent to the previous loop for dependency completion ordering. Worst case is a marginal allocation overhead from spawning a child task per dependency, which is negligible against the operations `AsyncQueue` is used for (indexing, request handling).
- **Testing**: Passes current test cases
- **Reviewers**: @hamishknight @owenv 
