### PR TITLE
Add missing dependencies in Package.swift and CMakeLists.txt

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -88,6 +88,7 @@ var targets: [Target] = [
   .testTarget(
     name: "LanguageServerProtocolTransportTests",
     dependencies: [
+      "LanguageServerProtocol",
       "LanguageServerProtocolTransport",
       "SKLogging",
       "ToolsProtocolsTestSupport",

--- a/Sources/LanguageServerProtocolTransport/CMakeLists.txt
+++ b/Sources/LanguageServerProtocolTransport/CMakeLists.txt
@@ -16,7 +16,8 @@ set_target_properties(LanguageServerProtocolTransport PROPERTIES
 target_link_libraries(LanguageServerProtocolTransport PRIVATE
   LanguageServerProtocol
   BuildServerProtocol
-  SKLogging)
+  SKLogging
+  ToolsProtocolsSwiftExtensions)
 target_link_libraries(LanguageServerProtocolTransport PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftDispatch>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)


### PR DESCRIPTION
Add missing target  `dependencies`  in Package.swift or `target_link_libraries` in CMakeLists.txt