### PR TITLE
Unified implementation for `withTimeout` family

### DIFF
--- a/Sources/ToolsProtocolsSwiftExtensions/AsyncUtils.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/AsyncUtils.swift
@@ -249,13 +249,17 @@ public func withTimeoutResult<T: Sendable>(
     }
     // The for-await exits without a value only if the consuming task is cancelled.
     return .result(.failure(CancellationError()))
-  } taskPriorityChanged: {
-    // Spawning fresh tasks that await `bodyTask` and `timeoutTask` forces the runtime to
-    // escalate their priorities via the await chain so `body`'s `Task.currentPriority`
-    // reflects the elevated value.
-    let newPriority = Task.currentPriority
-    Task(priority: newPriority) { _ = await bodyTask.result }
-    Task(priority: newPriority) { _ = await timeoutTask.value }
+  } taskPriorityChanged: { newPriority in
+    if #available(macOS 26, iOS 26, macCatalyst 26, *) {
+      bodyTask.escalatePriority(to: newPriority)
+      timeoutTask.escalatePriority(to: newPriority)
+    } else {
+      // Spawning fresh tasks that await `bodyTask` and `timeoutTask` forces the runtime to
+      // escalate their priorities via the await chain so `body`'s `Task.currentPriority`
+      // reflects the elevated value.
+      Task(priority: newPriority) { _ = await bodyTask.result }
+      Task(priority: newPriority) { _ = await timeoutTask.value }
+    }
   }
 
   // Stop the still-pending timer; no-op if it already elapsed.

--- a/Sources/ToolsProtocolsSwiftExtensions/AsyncUtils.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/AsyncUtils.swift
@@ -204,127 +204,123 @@ extension Collection where Self: Sendable, Element: Sendable {
   }
 }
 
+@_spi(SourceKitLSP) @frozen
+public enum WithTimeoutResult<T: Sendable>: Sendable {
+  case result(T)
+  case timedOut
+}
+
+/// Executes `body` with a `duration` timeout.
+///
+/// Returns `.result(value)` if `body` finishes within `duration`, otherwise `.timedOut`.
+///
+/// On timeout: if `resultReceivedAfterTimeout` is provided, `body` keeps running and its
+/// eventual result is passed to that callback. Otherwise, `body` is cancelled.
+@_spi(SourceKitLSP)
+public func withTimeoutResult<T: Sendable>(
+  _ timeout: Duration,
+  body: @escaping @Sendable () async throws -> T,
+  resultReceivedAfterTimeout: (@Sendable (_ result: T) async -> Void)? = nil
+) async throws -> WithTimeoutResult<T> {
+  // Capture the priority here so it stays consistent across `bodyTask`, timeoutTask`,
+  // and `withTaskPriorityChangedHandler`'s initial state.
+  let priority = Task.currentPriority
+
+  let (stream, continuation) = AsyncStream<WithTimeoutResult<Result<T, any Error>>>.makeStream()
+  let bodyTask = Task(priority: priority) {
+    do {
+      let value = try await body()
+      continuation.yield(.result(.success(value)))
+      return value
+    } catch {
+      continuation.yield(.result(.failure(error)))
+      throw error
+    }
+  }
+  let timeoutTask = Task(priority: priority) {
+    do { try await Task.sleep(for: timeout) } catch { return }
+    continuation.yield(.timedOut)
+  }
+
+  let outcome = await withTaskPriorityChangedHandler(initialPriority: priority) {
+    () -> WithTimeoutResult<Result<T, any Error>> in
+    for await value in stream {
+      return value
+    }
+    // The for-await exits without a value only if the consuming task is cancelled.
+    return .result(.failure(CancellationError()))
+  } taskPriorityChanged: {
+    // Spawning fresh tasks that await `bodyTask` and `timeoutTask` forces the runtime to
+    // escalate their priorities via the await chain so `body`'s `Task.currentPriority`
+    // reflects the elevated value.
+    let newPriority = Task.currentPriority
+    Task(priority: newPriority) { _ = await bodyTask.result }
+    Task(priority: newPriority) { _ = await timeoutTask.value }
+  }
+
+  // Stop the still-pending timer; no-op if it already elapsed.
+  timeoutTask.cancel()
+
+  switch outcome {
+  case .result(let r):
+    // Cancel `bodyTask` if it's still running (cancellation-fallback case); no-op otherwise.
+    bodyTask.cancel()
+    return try .result(r.get())
+  case .timedOut:
+    if let resultReceivedAfterTimeout {
+      // Late-result dispatch: await body and deliver via callback.
+      Task { try? await resultReceivedAfterTimeout(bodyTask.value) }
+    } else {
+      bodyTask.cancel()
+    }
+    return .timedOut
+  }
+}
+
 /// Executes `body`. If it doesn't finish after `duration`, throws a `TimeoutError` and cancels `body`.
 ///
-/// `TimeoutError` is thrown immediately an the function does not wait for `body` to honor the cancellation.
+/// `TimeoutError` is thrown immediately; the function does not wait for `body` to honor the cancellation.
 ///
 /// If a `handle` is passed in and this `withTimeout` call times out, the thrown `TimeoutError` contains this handle.
 /// This way a caller can identify whether this call to `withTimeout` timed out or if a nested call timed out.
-package func withTimeout<T: Sendable>(
+@_spi(SourceKitLSP) @inlinable
+public func withTimeout<T: Sendable>(
   _ duration: Duration,
   handle: TimeoutHandle? = nil,
   _ body: @escaping @Sendable () async throws -> T
 ) async throws -> T {
-  // Get the priority with which to launch the body task here so that we can pass the same priority as the initial
-  // priority to `withTaskPriorityChangedHandler`. Otherwise, we can get into a race condition where bodyTask gets
-  // launched with a low priority, then the priority gets elevated before we call with `withTaskPriorityChangedHandler`,
-  // we thus don't receive a `taskPriorityChanged` and hence never increase the priority of `bodyTask`.
-  let priority = Task.currentPriority
-  var mutableTasks: [Task<Void, Error>] = []
-  let stream = AsyncThrowingStream<T, Error> { continuation in
-    let bodyTask = Task<Void, Error>(priority: priority) {
-      do {
-        let result = try await body()
-        continuation.yield(result)
-      } catch {
-        continuation.yield(with: .failure(error))
-      }
-    }
-
-    let timeoutTask = Task(priority: priority) {
-      try await Task.sleep(for: duration)
-      continuation.yield(with: .failure(TimeoutError(handle: handle)))
-      bodyTask.cancel()
-    }
-    mutableTasks = [bodyTask, timeoutTask]
-  }
-
-  let tasks = mutableTasks
-
-  defer {
-    // Be extra careful and ensure that we don't leave `bodyTask` or `timeoutTask` running when `withTimeout` finishes,
-    // eg. if `withTaskPriorityChangedHandler` adds some behavior that never executes `body` if the task gets cancelled.
-    for task in tasks {
-      task.cancel()
-    }
-  }
-
-  return try await withTaskPriorityChangedHandler(initialPriority: priority) {
-    for try await value in stream {
-      return value
-    }
-    // The only reason for the loop above to terminate is if the Task got cancelled or if the stream finishes
-    // (which it never does).
-    if Task.isCancelled {
-      // Throwing a `CancellationError` will make us return from `withTimeout`. We will cancel the `bodyTask` from the
-      // `defer` method above.
-      throw CancellationError()
-    } else {
-      preconditionFailure("Continuation never finishes")
-    }
-  } taskPriorityChanged: {
-    for task in tasks {
-      Task(priority: Task.currentPriority) {
-        _ = try? await task.value
-      }
-    }
+  switch try await withTimeoutResult(duration, body: body) {
+  case .result(let value): return value
+  case .timedOut: throw TimeoutError(handle: handle)
   }
 }
 
 /// Executes `body`. If it doesn't finish after `duration`, return `nil` and continue running body. When `body` returns
-/// a value after the timeout, `resultReceivedAfterTimeout` is called.
+/// a value or throws an error after the timeout, `resultReceivedAfterTimeout` is called with the outcome.
 ///
 /// - Important: `body` will not be cancelled when the timeout is received. Use the other overload of `withTimeout` if
 ///   `body` should be cancelled after `timeout`.
-package func withTimeout<T: Sendable>(
+@_spi(SourceKitLSP) @inlinable
+public func withTimeout<T: Sendable>(
   _ timeout: Duration,
   body: @escaping @Sendable () async throws -> T,
   resultReceivedAfterTimeout: @escaping @Sendable (_ result: T) async -> Void
 ) async throws -> T? {
-  let didHitTimeout = ThreadSafeBox<Bool>(initialValue: false)
-
-  let stream = AsyncThrowingStream<T?, Error> { continuation in
-    Task {
-      try await Task.sleep(for: timeout)
-      didHitTimeout.withLock { $0 = true }
-      continuation.yield(nil)
-    }
-
-    Task {
-      do {
-        let result = try await body()
-        if didHitTimeout.value {
-          await resultReceivedAfterTimeout(result)
-        }
-        continuation.yield(result)
-      } catch {
-        continuation.yield(with: .failure(error))
-      }
-    }
-  }
-
-  for try await value in stream {
-    return value
-  }
-  // The only reason for the loop above to terminate is if the Task got cancelled or if the continuation finishes
-  // (which it never does).
-  if Task.isCancelled {
-    throw CancellationError()
-  } else {
-    preconditionFailure("Continuation never finishes")
+  switch try await withTimeoutResult(timeout, body: body, resultReceivedAfterTimeout: resultReceivedAfterTimeout) {
+  case .result(let value): return value
+  case .timedOut: return nil
   }
 }
 
 /// Same as `withTimeout` above but allows `body` to return an optional value.
-package func withTimeout<T: Sendable>(
+@_spi(SourceKitLSP) @inlinable
+public func withTimeout<T: Sendable>(
   _ timeout: Duration,
   body: @escaping @Sendable () async throws -> T?,
   resultReceivedAfterTimeout: @escaping @Sendable (_ result: T?) async -> Void
 ) async throws -> T? {
-  let result: T?? = try await withTimeout(timeout, body: body, resultReceivedAfterTimeout: resultReceivedAfterTimeout)
-  switch result {
-  case .none: return nil
-  case .some(.none): return nil
-  case .some(.some(let value)): return value
+  switch try await withTimeoutResult(timeout, body: body, resultReceivedAfterTimeout: resultReceivedAfterTimeout) {
+  case .result(let value): return value
+  case .timedOut: return nil
   }
 }

--- a/Sources/ToolsProtocolsSwiftExtensions/Task+WithPriorityChangedHandler.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/Task+WithPriorityChangedHandler.swift
@@ -10,22 +10,58 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Synchronization
+
 /// Runs `operation`. If the task's priority changes while the operation is running, calls `taskPriorityChanged`.
 ///
-/// Since Swift Concurrency doesn't support direct observation of a task's priority, this polls the task's priority at
-/// `pollingInterval`.
-/// The function assumes that the original priority of the task is `initialPriority`. If the task priority changed
-/// compared to `initialPriority`, the `taskPriorityChanged` will be called.
-// Workaround formatter issue: https://github.com/swiftlang/swift-format/issues/1081
-// swift-format-ignore
-@_spi(SourceKitLSP) public func withTaskPriorityChangedHandler<T: Sendable>(
+/// Unlike `withTaskPriorityEscalationHandler`, this also calls `taskPriorityChanged` once at entry if the
+/// current task is already escalated from `initialPriority` — escalations that happened before the handler
+/// was registered would otherwise be invisible to the caller.
+///
+/// On platforms without the runtime-provided priority escalation hook (pre SwiftStdlib 6.2), falls back to
+/// polling `Task.currentPriority` every `pollingInterval`.
+@_spi(SourceKitLSP) @inlinable
+public func withTaskPriorityChangedHandler<T: Sendable>(
   initialPriority: TaskPriority = Task.currentPriority,
   pollingInterval: Duration = .seconds(0.1),
   @_inheritActorContext operation: nonisolated(nonsending) @escaping @Sendable () async throws -> T,
   taskPriorityChanged: @escaping @Sendable () -> Void
-) async throws -> T {
-  let lastPriority = ThreadSafeBox(initialValue: initialPriority)
-  let result: T? = try await withThrowingTaskGroup(of: Optional<T>.self) { taskGroup in
+) async rethrows -> T {
+  if #available(macOS 26, iOS 26, macCatalyst 26, *) {
+    return try await withTaskPriorityEscalationHandler(
+      operation: {
+        // If the task is already escalated from `initialPriority`, notify the caller;
+        // otherwise it wouldn't know about it because the handler hasn't been registered until now.
+        if Task.currentPriority > initialPriority {
+          Task { taskPriorityChanged() }
+        }
+        return try await operation()
+      },
+      onPriorityEscalated: { _, _ in taskPriorityChanged() }
+    )
+  } else {
+    return try await withTaskPriorityChangedHandlerLegacy(
+      initialPriority: initialPriority,
+      pollingInterval: pollingInterval,
+      operation: operation,
+      taskPriorityChanged: taskPriorityChanged
+    )
+  }
+}
+
+/// Polling-based fallback for ``withTaskPriorityChangedHandler`` on platforms without
+/// `withTaskPriorityEscalationHandler`. Exposed under `@_spi(Testing)` so tests can
+/// exercise this path even on platforms where the inlinable wrapper would dispatch to
+/// the stdlib hook.
+@_spi(Testing)
+public func withTaskPriorityChangedHandlerLegacy<T: Sendable>(
+  initialPriority: TaskPriority,
+  pollingInterval: Duration,
+  @_inheritActorContext operation: nonisolated(nonsending) @escaping @Sendable () async throws -> T,
+  taskPriorityChanged: @escaping @Sendable () -> Void
+) async rethrows -> T {
+  let lastPriority = RefBox(Atomic<TaskPriority.RawValue>(initialPriority.rawValue))
+  return try await withThrowingTaskGroup(of: Optional<T>.self) { taskGroup in
     defer {
       // We leave this closure when either we have received a result or we registered cancellation. In either case, we
       // want to make sure that we don't leave the body task or the priority watching task running.
@@ -36,15 +72,8 @@
         if Task.isCancelled {
           break
         }
-        let newPriority = Task.currentPriority
-        let didChange = lastPriority.withLock { lastPriority in
-          if newPriority != lastPriority {
-            lastPriority = newPriority
-            return true
-          }
-          return false
-        }
-        if didChange {
+        let newPriority = Task.currentPriority.rawValue
+        if newPriority != lastPriority.value.exchange(newPriority, ordering: .relaxed) {
           taskPriorityChanged()
         }
         do {
@@ -58,16 +87,12 @@
     taskGroup.addTask {
       try await operation()
     }
-    // The first task that watches the priority never finishes unless it is cancelled, so we are effectively await the
-    // `operation` task here.
-    // We do need to await the observation task as well so that priority escalation also affects the observation task.
+    // The watcher loops forever until cancelled, so iterating the group effectively awaits
+    // `operation`. The watcher is structured into the same task group so it inherits the
+    // parent's priority and is automatically escalated alongside `operation`.
     for try await case let value? in taskGroup {
       return value
     }
-    return nil
+    preconditionFailure("Task group exits only via operation's value or throw")
   }
-  guard let result else {
-    throw CancellationError()
-  }
-  return result
 }

--- a/Sources/ToolsProtocolsSwiftExtensions/Task+WithPriorityChangedHandler.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/Task+WithPriorityChangedHandler.swift
@@ -12,7 +12,8 @@
 
 import Synchronization
 
-/// Runs `operation`. If the task's priority changes while the operation is running, calls `taskPriorityChanged`.
+/// Runs `operation`. If the task's priority changes while the operation is running, calls `taskPriorityChanged`
+/// with the new priority.
 ///
 /// Unlike `withTaskPriorityEscalationHandler`, this also calls `taskPriorityChanged` once at entry if the
 /// current task is already escalated from `initialPriority` — escalations that happened before the handler
@@ -25,19 +26,20 @@ public func withTaskPriorityChangedHandler<T: Sendable>(
   initialPriority: TaskPriority = Task.currentPriority,
   pollingInterval: Duration = .seconds(0.1),
   @_inheritActorContext operation: nonisolated(nonsending) @escaping @Sendable () async throws -> T,
-  taskPriorityChanged: @escaping @Sendable () -> Void
+  taskPriorityChanged: @escaping @Sendable (_ newPriority: TaskPriority) -> Void
 ) async rethrows -> T {
   if #available(macOS 26, iOS 26, macCatalyst 26, *) {
     return try await withTaskPriorityEscalationHandler(
       operation: {
         // If the task is already escalated from `initialPriority`, notify the caller;
         // otherwise it wouldn't know about it because the handler hasn't been registered until now.
-        if Task.currentPriority > initialPriority {
-          Task { taskPriorityChanged() }
+        let currentPriority = Task.currentPriority
+        if currentPriority > initialPriority {
+          Task { taskPriorityChanged(currentPriority) }
         }
         return try await operation()
       },
-      onPriorityEscalated: { _, _ in taskPriorityChanged() }
+      onPriorityEscalated: { _, newPriority in taskPriorityChanged(newPriority) }
     )
   } else {
     return try await withTaskPriorityChangedHandlerLegacy(
@@ -58,7 +60,7 @@ public func withTaskPriorityChangedHandlerLegacy<T: Sendable>(
   initialPriority: TaskPriority,
   pollingInterval: Duration,
   @_inheritActorContext operation: nonisolated(nonsending) @escaping @Sendable () async throws -> T,
-  taskPriorityChanged: @escaping @Sendable () -> Void
+  taskPriorityChanged: @escaping @Sendable (_ newPriority: TaskPriority) -> Void
 ) async rethrows -> T {
   let lastPriority = RefBox(Atomic<TaskPriority.RawValue>(initialPriority.rawValue))
   return try await withThrowingTaskGroup(of: Optional<T>.self) { taskGroup in
@@ -74,7 +76,7 @@ public func withTaskPriorityChangedHandlerLegacy<T: Sendable>(
         }
         let newPriority = Task.currentPriority.rawValue
         if newPriority != lastPriority.value.exchange(newPriority, ordering: .relaxed) {
-          taskPriorityChanged()
+          taskPriorityChanged(TaskPriority(rawValue: newPriority))
         }
         do {
           try await Task.sleep(for: pollingInterval)

--- a/Tests/ToolsProtocolsSwiftExtensionsTests/AsyncUtilsTests.swift
+++ b/Tests/ToolsProtocolsSwiftExtensionsTests/AsyncUtilsTests.swift
@@ -87,7 +87,7 @@ final class AsyncUtilsTests: XCTestCase {
             return callbackCalled.value
           }
         },
-        taskPriorityChanged: {
+        taskPriorityChanged: { _ in
           callbackCalled.withLock { $0 = true }
         }
       )
@@ -108,7 +108,7 @@ final class AsyncUtilsTests: XCTestCase {
         let value: String? = nil
         return value
       },
-      taskPriorityChanged: {}
+      taskPriorityChanged: { _ in }
     )
     XCTAssertNil(result)
   }
@@ -126,7 +126,7 @@ final class AsyncUtilsTests: XCTestCase {
             return callbackCalled.value
           }
         },
-        taskPriorityChanged: {
+        taskPriorityChanged: { _ in
           callbackCalled.withLock { $0 = true }
         }
       )
@@ -145,7 +145,7 @@ final class AsyncUtilsTests: XCTestCase {
         initialPriority: Task.currentPriority,
         pollingInterval: .milliseconds(100),
         operation: { throw TestError() },
-        taskPriorityChanged: {}
+        taskPriorityChanged: { _ in }
       )
     ) { error in
       XCTAssert(error is TestError, "Received unexpected error \(error)")

--- a/Tests/ToolsProtocolsSwiftExtensionsTests/AsyncUtilsTests.swift
+++ b/Tests/ToolsProtocolsSwiftExtensionsTests/AsyncUtilsTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(SourceKitLSP) import SKLogging
-@_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
+@_spi(SourceKitLSP) @_spi(Testing) import ToolsProtocolsSwiftExtensions
 import ToolsProtocolsTestSupport
 import XCTest
 
@@ -72,5 +72,109 @@ final class AsyncUtilsTests: XCTestCase {
     try await Task(priority: .high) {
       try await task.value
     }.value
+  }
+
+  func testWithTaskPriorityChangedHandlerCallsCallbackIfAlreadyEscalated() async throws {
+    // Verify `taskPriorityChanged` is called even when the escalation happens before the handler
+    // is registered.
+    let callbackCalled = ThreadSafeBox(initialValue: false)
+    let task = Task(priority: .background) {
+      try await withTaskPriorityChangedHandler(
+        initialPriority: .background,
+        pollingInterval: .milliseconds(50),
+        operation: {
+          try await repeatUntilExpectedResult(timeout: .seconds(10), sleepInterval: .milliseconds(50)) {
+            return callbackCalled.value
+          }
+        },
+        taskPriorityChanged: {
+          callbackCalled.withLock { $0 = true }
+        }
+      )
+    }
+    try await Task(priority: .high) {
+      try await task.value
+    }.value
+    XCTAssertTrue(callbackCalled.value)
+  }
+
+  func testWithTaskPriorityChangedHandlerLegacyReturnsOptionalNilFromOperation() async throws {
+    // When the operation's `T` is itself an `Optional`, verify `nil` return
+    // value is propagated as the operation's result.
+    let result: String? = try await withTaskPriorityChangedHandlerLegacy(
+      initialPriority: Task.currentPriority,
+      pollingInterval: .milliseconds(100),
+      operation: {
+        let value: String? = nil
+        return value
+      },
+      taskPriorityChanged: {}
+    )
+    XCTAssertNil(result)
+  }
+
+  func testWithTaskPriorityChangedHandlerLegacyDetectsPriorityEscalation() async throws {
+    let started = self.expectation(description: "Operation started")
+    let callbackCalled = ThreadSafeBox(initialValue: false)
+    let task = Task(priority: .background) {
+      try await withTaskPriorityChangedHandlerLegacy(
+        initialPriority: .background,
+        pollingInterval: .milliseconds(50),
+        operation: {
+          started.fulfill()
+          try await repeatUntilExpectedResult(sleepInterval: .milliseconds(100)) {
+            return callbackCalled.value
+          }
+        },
+        taskPriorityChanged: {
+          callbackCalled.withLock { $0 = true }
+        }
+      )
+    }
+    try await fulfillmentOfOrThrow(started)
+    try await Task(priority: .high) {
+      try await task.value
+    }.value
+    XCTAssertTrue(callbackCalled.value)
+  }
+
+  func testWithTaskPriorityChangedHandlerLegacyRethrowsError() async throws {
+    struct TestError: Error {}
+    await assertThrowsError(
+      try await withTaskPriorityChangedHandlerLegacy(
+        initialPriority: Task.currentPriority,
+        pollingInterval: .milliseconds(100),
+        operation: { throw TestError() },
+        taskPriorityChanged: {}
+      )
+    ) { error in
+      XCTAssert(error is TestError, "Received unexpected error \(error)")
+    }
+  }
+
+  func testWithTaskPriorityChangedHandlerLegacyExitsCleanly() async throws {
+    // Verify the operation's error propagates out when the outer task is cancelled and the
+    // operation delays honoring cancellation, instead of tripping the post-loop precondition.
+    struct OperationError: Error {}
+    let task = Task {
+      try await withTaskPriorityChangedHandlerLegacy(
+        initialPriority: Task.currentPriority,
+        pollingInterval: .milliseconds(50),
+        operation: {
+          // Ignore cancellation for a short window, then surface a custom error from the operation.
+          for _ in 0..<5 {
+            try? await Task.sleep(for: .milliseconds(20))
+          }
+          throw OperationError()
+        },
+        taskPriorityChanged: { _ in }
+      )
+    }
+    // Cancel after operation has started.
+    try await Task.sleep(for: .milliseconds(10))
+    task.cancel()
+    await assertThrowsError(try await task.value) { error in
+      XCTAssert(error is OperationError, "Received unexpected error \(error)")
+    }
   }
 }


### PR DESCRIPTION
Introduce `withTimeoutResult(_:body:resultReceivedAfterTimeout:)` returning a `WithTimeoutResult<T>` enum (`.result(T)`/ `.timedOut`). Existing `withTimeout` overloads become thin switches over it. The optional late-result callback receives successful late results only.

`withTaskPriorityChangedHandler` now delegates to stdlib's `withTaskPriorityEscalationHandler` on macOS 26+, giving native priority reaction instead of polling.

Added some test cases to ensure the old `withTaskPriorityChangedHandler` implementation keep working even when testing with `withTaskPriorityEscalationHandler`.