### PR TITLE
RefBox: drop @inlinable from init to allow resilient builds

### DIFF
--- a/Sources/ToolsProtocolsSwiftExtensions/RefBox.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/RefBox.swift
@@ -16,7 +16,7 @@
 @_spi(SourceKitLSP) public final class RefBox<Value: ~Copyable> {
   public let value: Value
 
-  @inlinable public init(_ value: consuming Value) {
+  public init(_ value: consuming Value) {
     self.value = value
   }
 }


### PR DESCRIPTION
In a resilient build, an `@inlinable` initializer of a class must delegate to another initializer. RefBox's init does a direct stored-property assignment with no delegation, so the build fails:

```
error: initializer for class 'RefBox<Value>' is '@inlinable' and must delegate to another initializer
```

Drop the annotation; the rest of the type is unaffected.