### PR TITLE
Make some SwiftExtensions APIs to `@_spi(SourceKitLSP) public`

### DIFF
--- a/Sources/LanguageServerProtocolTransport/BuildServerMessageDependencyTracker.swift
+++ b/Sources/LanguageServerProtocolTransport/BuildServerMessageDependencyTracker.swift
@@ -13,7 +13,7 @@
 import BuildServerProtocol
 public import LanguageServerProtocol
 @_spi(SourceKitLSP) import SKLogging
-import ToolsProtocolsSwiftExtensions
+@_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
 
 /// A lightweight way of describing tasks that are created from handling BSP
 /// requests or notifications for the purpose of dependency tracking.

--- a/Sources/SKLogging/SetGlobalLogFileHandler.swift
+++ b/Sources/SKLogging/SetGlobalLogFileHandler.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import RegexBuilder
-import ToolsProtocolsSwiftExtensions
+@_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
 
 #if canImport(Darwin)
 public import Foundation

--- a/Sources/ToolsProtocolsSwiftExtensions/Collection+Only.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/Collection+Only.swift
@@ -10,9 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-package extension Collection {
+extension Collection {
   /// If the collection contains a single element, return it, otherwise `nil`.
-  var only: Element? {
+  @_spi(SourceKitLSP) @inlinable
+  public var only: Element? {
     if !isEmpty && index(after: startIndex) == endIndex {
       return self.first!
     } else {

--- a/Sources/ToolsProtocolsSwiftExtensions/Duration+Seconds.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/Duration+Seconds.swift
@@ -11,7 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 extension Duration {
-  package var seconds: Double {
+  @_spi(SourceKitLSP) @inlinable
+  public var seconds: Double {
     return Double(self.components.attoseconds) / 1_000_000_000_000_000_000 + Double(self.components.seconds)
   }
 }

--- a/Sources/ToolsProtocolsSwiftExtensions/FileManagerExtensions.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/FileManagerExtensions.swift
@@ -10,11 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import Foundation
+public import Foundation
 
 extension FileManager {
   /// Same as `fileExists(atPath:)` but takes a `URL` instead of a `String`.
-  package func fileExists(at url: URL) -> Bool {
+  @_spi(SourceKitLSP) @inlinable
+  public func fileExists(at url: URL) -> Bool {
     guard let filePath = try? url.filePath else {
       return false
     }
@@ -22,21 +23,24 @@ extension FileManager {
   }
 
   /// Returns `true` if an entry exists in the file system at the given URL and that entry is a directory.
-  package func isDirectory(at url: URL) -> Bool {
+  @_spi(SourceKitLSP) @inlinable
+  public func isDirectory(at url: URL) -> Bool {
     var isDirectory: ObjCBool = false
     return self.fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
   }
 
   /// Returns `true` if an entry exists in the file system at the given URL and that entry is a file, ie. not a
   /// directory.
-  package func isFile(at url: URL) -> Bool {
+  @_spi(SourceKitLSP) @inlinable
+  public func isFile(at url: URL) -> Bool {
     var isDirectory: ObjCBool = false
     return self.fileExists(atPath: url.path, isDirectory: &isDirectory) && !isDirectory.boolValue
   }
 
   /// Same as `createFile(atPath:data:attributes)` but throws an error when file creation fails instead of returning
   /// `false`.
-  package func createFile(at url: URL, contents data: Data?, attributes: [FileAttributeKey: Any]? = nil) throws {
+  @_spi(SourceKitLSP)
+  public func createFile(at url: URL, contents data: Data?, attributes: [FileAttributeKey: Any]? = nil) throws {
     struct FileCreationFailed: Error, CustomStringConvertible {
       let url: URL
       var description: String {

--- a/Sources/ToolsProtocolsSwiftExtensions/PipeAsStringHandler.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/PipeAsStringHandler.swift
@@ -10,11 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import Foundation
+public import Foundation
 
 /// Gathers data from a stdout or stderr pipe. When it has accumulated a full line, calls the handler to handle the
 /// string.
-package actor PipeAsStringHandler {
+@_spi(SourceKitLSP)
+public actor PipeAsStringHandler {
   /// Queue on which all data from the pipe will be handled. This allows us to have a
   /// nonisolated `handle` function but ensure that data gets processed in order.
   private let queue = AsyncQueue<Serial>()
@@ -23,7 +24,7 @@ package actor PipeAsStringHandler {
   /// The closure that actually handles
   private let handler: @Sendable (String) -> Void
 
-  package init(handler: @escaping @Sendable (String) -> Void) {
+  public init(handler: @escaping @Sendable (String) -> Void) {
     self.handler = handler
   }
 
@@ -49,7 +50,7 @@ package actor PipeAsStringHandler {
     }
   }
 
-  package nonisolated func handleDataFromPipe(_ newData: Data) {
+  public nonisolated func handleDataFromPipe(_ newData: Data) {
     queue.async {
       await self.handleDataFromPipeImpl(newData)
     }

--- a/Sources/ToolsProtocolsSwiftExtensions/URLExtensions.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/URLExtensions.swift
@@ -10,22 +10,29 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import Foundation
+public import Foundation
 
 #if os(Windows)
 import WinSDK
 #endif
 
-enum FilePathError: Error, CustomStringConvertible {
+@_spi(SourceKitLSP) @frozen
+public enum FilePathError: Error, CustomStringConvertible {
   case noFileSystemRepresentation(URL)
   case noFileURL(URL)
+  case circularSymlink(URL)
+  case fileAttributesDontHaveModificationDate(URL)
 
-  var description: String {
+  public var description: String {
     switch self {
     case .noFileSystemRepresentation(let url):
       return "\(url.description) cannot be represented as a file system path"
     case .noFileURL(let url):
       return "\(url.description) is not a file URL"
+    case .circularSymlink(let url):
+      return "Circular symlink at \(url)"
+    case .fileAttributesDontHaveModificationDate(let url):
+      return "File attributes don't contain a modification date: \(url)"
     }
   }
 }
@@ -37,7 +44,8 @@ extension URL {
   ///   path by stripping away `private` prefixes. Since sourcekitd is not performing this standardization, using
   ///   `resolvingSymlinksInPath` can lead to slightly mismatched URLs between the sourcekit-lsp response and the test
   ///   assertion.
-  package var realpath: URL {
+  @_spi(SourceKitLSP)
+  public var realpath: URL {
     get throws {
       #if canImport(Darwin)
       return try self.filePath.withCString { path in
@@ -63,7 +71,8 @@ extension URL {
   /// - It throws an error when called on a non-file URL.
   ///
   /// `filePath` should generally be preferred over `path` when dealing with file URLs.
-  package var filePath: String {
+  @_spi(SourceKitLSP)
+  public var filePath: String {
     get throws {
       guard self.isFileURL else {
         throw FilePathError.noFileURL(self)
@@ -89,7 +98,8 @@ extension URL {
 
   /// Assuming this URL is a file URL, checks if it looks like a root path. This is a string check, ie. the return
   /// value for a path of `"/foo/.."` would be `false`. An error will be thrown is this is a non-file URL.
-  package var isRoot: Bool {
+  @_spi(SourceKitLSP)
+  public var isRoot: Bool {
     get throws {
       let checkPath = try filePath
       #if os(Windows)
@@ -101,7 +111,42 @@ extension URL {
   }
 
   /// Returns true if the path of `self` starts with the path in `other`.
-  package func isDescendant(of other: URL) -> Bool {
+  @_spi(SourceKitLSP) @inlinable
+  public func isDescendant(of other: URL) -> Bool {
     return self.pathComponents.dropLast().starts(with: other.pathComponents)
+  }
+
+  /// Assuming this URL is a file URL, returns the modification date of the file.
+  ///
+  /// For symbolic links, returns the most recent modification date in the symlink chain, which updates when
+  /// either the symlink or the target file is modified.
+  @_spi(SourceKitLSP)
+  public var fileModificationDate: Date {
+    get throws {
+      var mtime = Date.distantPast
+      let fileManager = FileManager.default
+      var visitedURLs: Set<URL> = []
+      var url = self
+      while true {
+        let path = try url.filePath
+        let fileAttrs = try fileManager.attributesOfItem(atPath: path)
+
+        guard let fileModTime = fileAttrs[FileAttributeKey.modificationDate] as? Date else {
+          throw FilePathError.fileAttributesDontHaveModificationDate(url)
+        }
+        mtime = max(mtime, fileModTime)
+
+        // Follow the symlink and find the most recent mtime.
+        if let symLinkPath = try? fileManager.destinationOfSymbolicLink(atPath: path) {
+          url = URL(filePath: symLinkPath, relativeTo: url)
+          guard visitedURLs.insert(url).inserted else {
+            throw FilePathError.circularSymlink(url)
+          }
+        } else {
+          break
+        }
+      }
+      return mtime
+    }
   }
 }


### PR DESCRIPTION
Expose APIs as `@_spi(SourceKitLSP) public` so they can be used cross-module by SourceKit-LSP.
* `Collection.only`
* `Duration.seconds`
* `FileManager` extensions
* `PipeAsStringHandler`
* `FilePathError`
* `URL` extensions

Add `@inlinable` to simple computed properties / single-line wrappers
* `Collection.only`
*  `Duration.seconds`
*  `FileManager`'s `fileExists`/`isDirectory`/`isFile`
* `URL.isDescendant(of:)`

Mark `@frozen`
* `FilePathError`

Move `URL.fileModificationDate` and the two `FilePathError` cases (`circularSymlink`, `fileAttributesDontHaveModificationDate`) from sourcekit-lsp