### PR TITLE
docs: fix typos and copy-paste error in LSP/BSP comments

### DIFF
--- a/Sources/BuildServerProtocol/Messages/TaskFinishNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/TaskFinishNotification.swift
@@ -13,7 +13,7 @@
 public import Foundation
 public import LanguageServerProtocol
 
-/// A `build/taskFinish` notification must always be sent after a `build/taskStart`` with the same `taskId` was sent.
+/// A `build/taskFinish` notification must always be sent after a `build/taskStart` with the same `taskId` was sent.
 public struct TaskFinishNotification: BSPNotification {
   public static let method: String = "build/taskFinish"
 
@@ -92,7 +92,7 @@ public struct CompileReportData: Codable, Hashable, Sendable {
 
   /// An optional request id to know the origin of this report.
   ///
-  /// Deprecated: Use the field in TaskFinishParams instead .
+  /// Deprecated: Use the field in TaskFinishParams instead.
   public var originId: String?
 
   /// The total number of reported errors compiling this target.
@@ -178,7 +178,7 @@ public struct TestFinishData: Codable, Hashable, Sendable {
   /// The test execution was cancelled.
   case cancelled = 4
 
-  /// The was not included in execution.
+  /// The test was not included in execution.
   case skipped = 5
 }
 
@@ -193,7 +193,7 @@ public struct TestFinishDataKind: RawRepresentable, Codable, Hashable, Sendable 
 /// This structure is embedded in the `TaskFinishNotification.data` field, when the `dataKind` field contains
 /// `"test-report"`.
 public struct TestReportData: Codable, Hashable, Sendable {
-  /// Deprecated: Use the field in TaskFinishParams instead
+  /// Deprecated: Use the field in TaskFinishParams instead.
   public var originId: String?
 
   /// The build target that was compiled.

--- a/Sources/LanguageServerProtocol/Notifications/WorkDoneProgress.swift
+++ b/Sources/LanguageServerProtocol/Notifications/WorkDoneProgress.swift
@@ -79,7 +79,7 @@ public struct WorkDoneProgressBegin: Codable, Hashable, Sendable {
 
   /// Optional progress percentage to display (value 100 is considered 100%).
   /// If not provided infinite progress is assumed and clients are allowed
-  /// to ignore the `percentage` value in subsequent in report notifications.
+  /// to ignore the `percentage` value in subsequent report notifications.
   ///
   /// The value should be steadily rising. Clients are free to ignore values
   /// that are not following this rule. The value range is [0, 100]
@@ -131,7 +131,7 @@ public struct WorkDoneProgressReport: Codable, Hashable, Sendable {
   /// Controls enablement state of a cancel button. This property is only valid
   /// if a cancel button got requested in the `WorkDoneProgressBegin` payload.
   ///
-  /// Clients that don't support cancellation or don't support control the
+  /// Clients that don't support cancellation or don't support controlling the
   /// button's enablement state are allowed to ignore the setting.
   public var cancellable: Bool?
 
@@ -144,7 +144,7 @@ public struct WorkDoneProgressReport: Codable, Hashable, Sendable {
 
   /// Optional progress percentage to display (value 100 is considered 100%).
   /// If not provided infinite progress is assumed and clients are allowed
-  /// to ignore the `percentage` value in subsequent in report notifications.
+  /// to ignore the `percentage` value in subsequent report notifications.
   ///
   /// The value should be steadily rising. Clients are free to ignore values
   /// that are not following this rule. The value range is [0, 100]
@@ -189,7 +189,7 @@ public struct WorkDoneProgressReport: Codable, Hashable, Sendable {
 }
 
 public struct WorkDoneProgressEnd: Codable, Hashable, Sendable {
-  /// Optional, a final message indicating to for example indicate the outcome
+  /// Optional, a final message indicating, for example, the outcome
   /// of the operation.
   public var message: String?
 
@@ -209,7 +209,7 @@ public struct WorkDoneProgressEnd: Codable, Hashable, Sendable {
       throw DecodingError.dataCorruptedError(
         forKey: .kind,
         in: container,
-        debugDescription: "Kind of WorkDoneProgressReport is not 'end'"
+        debugDescription: "Kind of WorkDoneProgressEnd is not 'end'"
       )
     }
 

--- a/Sources/LanguageServerProtocol/Requests/CompletionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CompletionRequest.swift
@@ -68,7 +68,7 @@ public struct CompletionContext: Codable, Hashable, Sendable {
   /// How the completion was triggered.
   public var triggerKind: CompletionTriggerKind
 
-  /// The trigger character (a single character) that has trigger code complete. Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+  /// The trigger character (a single character) that has triggered code completion. Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
   public var triggerCharacter: String?
 
   public init(triggerKind: CompletionTriggerKind, triggerCharacter: String? = nil) {

--- a/Sources/LanguageServerProtocol/Requests/SignatureHelpRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/SignatureHelpRequest.swift
@@ -90,7 +90,7 @@ public struct SignatureHelpContext: Codable, Hashable, Sendable {
 }
 
 /// Signature help represents the signature of something
-/// callable. There can be multiple signature but only one
+/// callable. There can be multiple signatures but only one
 /// active and only one active parameter.
 public struct SignatureHelp: ResponseType, Hashable {
   /// One or more signatures. If no signatures are available the signature help
@@ -98,8 +98,8 @@ public struct SignatureHelp: ResponseType, Hashable {
   public var signatures: [SignatureInformation]
 
   /// The active signature. If omitted or the value lies outside the
-  /// range of `signatures` the value defaults to zero or is ignore if
-  /// the `SignatureHelp` as no signatures.
+  /// range of `signatures` the value defaults to zero or is ignored if
+  /// the `SignatureHelp` has no signatures.
   ///
   /// Whenever possible implementors should make an active decision about
   /// the active signature and shouldn't rely on a default value.


### PR DESCRIPTION
## Summary

Fix 13 documentation issues across 4 files in the LSP and BSP protocol types:

**WorkDoneProgress.swift:**
- Fix "subsequent in report" → "subsequent report" (appeared in both `WorkDoneProgressBegin` and `WorkDoneProgressReport`)
- Fix "don't support control the" → "don't support controlling the"
- Fix "indicating to for example indicate" → "indicating, for example,"
- Fix incorrect `debugDescription` in `WorkDoneProgressEnd` decoder: referenced `WorkDoneProgressReport` instead of `WorkDoneProgressEnd`

**CompletionRequest.swift:**
- Fix "has trigger code complete" → "has triggered code completion"

**SignatureHelpRequest.swift:**
- Fix "multiple signature but" → "multiple signatures but"
- Fix "is ignore if" → "is ignored if"
- Fix "as no signatures" → "has no signatures"

**TaskFinishNotification.swift:**
- Fix extra backtick in `` `build/taskStart` `` reference
- Fix "The was not included" → "The test was not included" in `TestStatus.skipped`
- Fix trailing space before period in `CompileReportData.originId` deprecation comment
- Add missing period to `TestReportData.originId` deprecation comment

No functional changes — all fixes are in doc comments except the `debugDescription` string correction in `WorkDoneProgressEnd`, which fixes a potentially misleading error message.