### PR TITLE
Read subprocess stderr with a blocking loop instead of `readabilityHandler`

### DIFF
--- a/Sources/LanguageServerProtocolTransport/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolTransport/JSONRPCConnection.swift
@@ -16,8 +16,16 @@ public import LanguageServerProtocol
 import Synchronization
 @_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
 
-#if canImport(Android)
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Android)
 import Android
+#elseif canImport(WinSDK)
+import WinSDK
 #endif
 
 #if canImport(CDispatch)
@@ -187,13 +195,11 @@ public final class JSONRPCConnection: Connection {
       Logger(subsystem: LoggingScope.subsystem, category: stderrLoggingCategory).info("\($0)")
     }
     let stderrHandler = Pipe()
-    stderrHandler.fileHandleForReading.readabilityHandler = { fileHandle in
-      let newData = fileHandle.availableData
-      if newData.count == 0 {
-        stderrHandler.fileHandleForReading.readabilityHandler = nil
-      } else {
-        logForwarder.handleDataFromPipe(newData)
-      }
+    Self.readInBackground(
+      fileHandle: stderrHandler.fileHandleForReading,
+      queueLabel: "\(name)-stderr-read-queue"
+    ) { data in
+      logForwarder.handleDataFromPipe(data)
     }
     process.standardError = stderrHandler
     process.terminationHandler = { process in
@@ -221,6 +227,73 @@ public final class JSONRPCConnection: Connection {
     return (connection, process)
   }
   #endif  // os(macOS) || !canImport(Darwin)
+
+  /// Read from `fileHandle` on a dedicated background queue with a blocking loop, forwarding each chunk to
+  /// `receiveData` until end-of-file, then invoke `reachedEndOfFile`.
+  ///
+  /// A blocking read is used rather than a `readabilityHandler`. `readabilityHandler` installs a libdispatch
+  /// read source on the file descriptor; tearing that source down races epoll event delivery on Linux and
+  /// can crash the process in `_dispatch_event_loop_drain`. A blocking read never registers the descriptor
+  /// with libdispatch. See https://github.com/swiftlang/swift-corelibs-libdispatch/issues/949.
+  ///
+  /// The raw file descriptor is read instead of `FileHandle.read(upToCount:)`: on non-Darwin platforms the
+  /// latter blocks until it accumulates the full requested count or reaches EOF, which would withhold small,
+  /// intermittently emitted output until the writer closes the pipe. A raw `read` returns as soon as any
+  /// bytes are available. On Windows the file descriptor is unavailable and the crash does not occur, so a
+  /// `readabilityHandler` read source is used there.
+  ///
+  /// A read failure other than `EINTR` is logged and ends the loop.
+  @_spi(Testing)
+  public static func readInBackground(
+    fileHandle: FileHandle,
+    queueLabel: String,
+    receiveData: @Sendable @escaping (Data) -> Void,
+    reachedEndOfFile: (@Sendable () -> Void)? = nil
+  ) {
+    #if os(Windows)
+    // `FileHandle.fileDescriptor` is unavailable on Windows. The libdispatch epoll crash has not occurred
+    // on Windows, so a `readabilityHandler` read source is used there.
+    fileHandle.readabilityHandler = { handle in
+      let data = handle.availableData
+      if data.isEmpty {
+        handle.readabilityHandler = nil
+        reachedEndOfFile?()
+      } else {
+        receiveData(data)
+      }
+    }
+    #else
+    let fileDescriptor = fileHandle.fileDescriptor
+    let queue = DispatchQueue(label: queueLabel)
+    queue.async {
+      var buffer = [UInt8](repeating: 0, count: 8 * 1024)
+      while true {
+        let (bytesRead, readErrno) = buffer.withUnsafeMutableBytes { ptr -> (Int, CInt) in
+          let count = read(fileDescriptor, ptr.baseAddress, ptr.count)
+          return (count, errno)
+        }
+        if bytesRead > 0 {
+          receiveData(Data(buffer[0..<bytesRead]))
+        } else if bytesRead == 0 {
+          // End-of-file: the writer closed the pipe.
+          break
+        } else if readErrno == EINTR {
+          // Interrupted by a signal; retry the read.
+          continue
+        } else {
+          logger.error(
+            "Reading \(queueLabel, privacy: .public) failed: \(String(cString: strerror(readErrno)), privacy: .public) (errno \(readErrno))"
+          )
+          break
+        }
+      }
+      // Keep the handle alive for the duration of the loop so its file descriptor is not closed while
+      // `read` is blocked on it.
+      withExtendedLifetime(fileHandle) {}
+      reachedEndOfFile?()
+    }
+    #endif
+  }
 
   deinit {
     assert(state == .closed)

--- a/Tests/LanguageServerProtocolTransportTests/PipeForwardingTests.swift
+++ b/Tests/LanguageServerProtocolTransportTests/PipeForwardingTests.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Testing) import LanguageServerProtocolTransport
+import Synchronization
+import ToolsProtocolsTestSupport
+import XCTest
+
+import struct Foundation.Data
+import class Foundation.Pipe
+
+final class PipeForwardingTests: XCTestCase {
+  /// `readInBackground` forwards everything written to the pipe and signals end-of-file once the write end
+  /// is closed.
+  func testReadInBackgroundForwardsAllDataAndSignalsEndOfFile() async throws {
+    let pipe = Pipe()
+    let received = Mutex<Data>(Data())
+    let reachedEndOfFile = expectation(description: "reached end of file")
+
+    JSONRPCConnection.readInBackground(
+      fileHandle: pipe.fileHandleForReading,
+      queueLabel: "test-read-in-background"
+    ) { data in
+      received.withLock { $0.append(data) }
+    } reachedEndOfFile: {
+      reachedEndOfFile.fulfill()
+    }
+
+    try pipe.fileHandleForWriting.write(contentsOf: Data("hello".utf8))
+    try pipe.fileHandleForWriting.write(contentsOf: Data(" world".utf8))
+    try pipe.fileHandleForWriting.close()
+
+    try await fulfillmentOfOrThrow(reachedEndOfFile)
+    XCTAssertEqual(received.withLock { $0 }, Data("hello world".utf8))
+  }
+
+  /// `readInBackground` delivers data as soon as it is available, before the pipe reaches end-of-file. A
+  /// read that accumulated until its buffer filled or EOF (as `FileHandle.read(upToCount:)` does on
+  /// non-Darwin platforms) would withhold this small chunk until the write end is closed.
+  func testReadInBackgroundDeliversDataBeforeEndOfFile() async throws {
+    let pipe = Pipe()
+    let received = Mutex<Data>(Data())
+    let receivedChunk = expectation(description: "received chunk before EOF")
+    receivedChunk.assertForOverFulfill = false
+
+    JSONRPCConnection.readInBackground(
+      fileHandle: pipe.fileHandleForReading,
+      queueLabel: "test-read-in-background-prompt"
+    ) { data in
+      let total = received.withLock {
+        $0.append(data); return $0
+      }
+      if total == Data("ping".utf8) {
+        receivedChunk.fulfill()
+      }
+    }
+
+    // Do not close the write end: the chunk must be delivered without relying on EOF.
+    try pipe.fileHandleForWriting.write(contentsOf: Data("ping".utf8))
+    try await fulfillmentOfOrThrow(receivedChunk)
+
+    // Let the read loop terminate so its background thread does not outlive the test.
+    try pipe.fileHandleForWriting.close()
+  }
+}


### PR DESCRIPTION
`JSONRPCConnection`'s subprocess launcher reads the child's stderr (e.g. clangd's) via `FileHandle.readabilityHandler`, which installs a libdispatch read source on the pipe's file descriptor. Tearing that source down can race the descriptor being closed, which has intermittently crashed the process in `_dispatch_event_loop_drain` on Linux CI while a subprocess connection is torn down — a dangling epoll muxnote left behind by the source cancellation.

This drains the subprocess's stderr with a blocking read loop on a dedicated queue instead. A blocking read never registers the file descriptor with libdispatch's event loop, so no read source (and no epoll muxnote) is created for the pipe. This mirrors the approach already used for the `receiveFD` read loop in the same file, where the JSON-RPC input is read with blocking reads rather than a dispatch source. End of stream ends the loop; there is no asynchronous source cancellation to race the descriptor close.

This is a speculative workaround for https://github.com/swiftlang/sourcekit-lsp/issues/2717: the underlying defect is a teardown race in the runtime (Foundation `FileHandle` / libdispatch), tracked separately in https://github.com/swiftlang/swift-corelibs-foundation/pull/5507. This PR removes the only libdispatch read source in the subprocess connection path — `Process` monitoring on Linux uses CFRunLoop and the JSON-RPC pipes are already read with blocking reads — so it sidesteps the crash without changing observable behavior (stderr is still forwarded to the log).