### PR TITLE
Add DocCSymbolLinkDefinition request

### DIFF
--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(LanguageServerProtocol
   Requests/DefinitionRequest.swift
   Requests/DiagnosticsRefreshRequest.swift
   Requests/DoccDocumentationRequest.swift
+  Requests/DoccSymbolLinkDefinitionRequest.swift
   Requests/DocumentColorRequest.swift
   Requests/DocumentDiagnosticsRequest.swift
   Requests/DocumentHighlightRequest.swift

--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -33,6 +33,7 @@ public let builtinRequests: [_RequestType.Type] = [
   DefinitionRequest.self,
   DiagnosticsRefreshRequest.self,
   DoccDocumentationRequest.self,
+  DocCSymbolLinkDefinitionRequest.self,
   DocumentColorRequest.self,
   DocumentDiagnosticsRequest.self,
   DocumentFormattingRequest.self,

--- a/Sources/LanguageServerProtocol/Requests/DoccSymbolLinkDefinitionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DoccSymbolLinkDefinitionRequest.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Request that resolves a DocC symbol link to the location of the symbol it refers to
+/// **(LSP Extension)**.
+///
+/// Primarily designed to support jump-to-definition when a symbol link is clicked within the live
+/// preview of Swift documentation in editors.
+///
+/// This request takes a DocC symbol link string (e.g. `"Foo/bar(_:)"`) along with the document it was
+/// clicked in and resolves it via the index to the location of the symbol's definition or declaration.
+///
+/// Resolution can fail for a number of reasons, most commonly because the symbol link could not be
+/// parsed, or because no matching symbol could be found in the index. In such cases the request
+/// returns `nil` rather than failing, since a symbol link not resolving is an expected outcome that
+/// the live preview editor can display to the user (e.g. "Symbol link could not be resolved" or
+/// "Symbol not found"), not a failure of the request itself.
+///
+/// At the moment this request is only available on macOS and Linux. SourceKit-LSP will advertise
+/// `textDocument/doccSymbolLinkDefinition` in its experimental server capabilities if it supports it.
+///
+/// - Parameters:
+///   - textDocument: The document the symbol link was clicked in, used to resolve the link relative
+///     to the correct workspace and index.
+///   - symbolLink: The DocC symbol link to resolve.
+///
+/// - Returns: The `Location` of the symbol's definition or declaration, or `nil` if the symbol link
+///   could not be parsed or no matching symbol was found in the index.
+///
+/// ### LSP Extension
+///
+/// This request is an extension to LSP supported by SourceKit-LSP.
+/// The client is expected to navigate to the returned location, or display an appropriate error
+/// message to the user if the response is `nil`.
+public struct DocCSymbolLinkDefinitionRequest: TextDocumentRequest, Hashable {
+  public static let method: String = "sourcekit/textDocument/doccSymbolLinkDefinition"
+  public typealias Response = LocationsOrLocationLinksResponse?
+
+  /// The document the symbol link was clicked in.
+  public var textDocument: TextDocumentIdentifier
+
+  /// The DocC symbol link to resolve.
+  public var symbolLink: String
+
+  public init(textDocument: TextDocumentIdentifier, symbolLink: String) {
+    self.textDocument = textDocument
+    self.symbolLink = symbolLink
+  }
+}

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -1079,6 +1079,23 @@ final class CodingTests: XCTestCase {
     )
   }
 
+  func testDocCSymbolLinkDefinitionRequest() throws {
+    checkDecoding(
+      json: #"""
+        {
+          "symbolLink" : "Foo/bar",
+          "textDocument" : {
+            "uri" : "file:///some/path"
+          }
+        }
+        """#,
+      expected: DocCSymbolLinkDefinitionRequest(
+        textDocument: TextDocumentIdentifier(try DocumentURI(string: "file:///some/path")),
+        symbolLink: "Foo/bar"
+      )
+    )
+  }
+
   func testWorkspaceDocumentDiagnosticReport() throws {
     checkCoding(
       WorkspaceDocumentDiagnosticReport.full(


### PR DESCRIPTION
### Summary
Adds `DocCSymbolLinkDefinitionRequest`, a new LSP extension request that resolves a DocC symbol link string to the location of the symbol it refers to.

### Motivation
Currently, symbol links in the DocC Live Preview are not clickable. To enable this, we need a new request that adds the functionality of navigating to the symbol's definition if it exists, or showing an error when it doesn't - making the preview interactive.

### Details
`DocCSymbolLinkDefinitionRequest` takes the symbol link string and the document's URI as arguments and returns the `Location` of where the symbol is defined.