### PR TITLE
Release the state of a cancelled request instead of awaiting its reply

### DIFF
--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -47,9 +47,24 @@ public protocol Connection: Sendable {
     id: RequestID,
     reply: @escaping @Sendable (LSPResult<Request.Response>) -> Void
   )
+
+  /// Stop expecting a reply for the request with the given ID and release the state that is held to
+  /// deliver it.
+  ///
+  /// A reply that the peer sends afterwards is discarded. This is called when nobody is interested
+  /// in the reply anymore, eg. because the task that awaits it was cancelled. A peer is required to
+  /// reply to every request, including one that was cancelled with `$/cancelRequest`, but a peer that
+  /// has become unresponsive may not do so. Without this, a conformer that tracks its in-flight
+  /// requests would hold their state until the connection is closed.
+  ///
+  /// The default implementation does nothing, which is correct for conformers that don't hold any
+  /// state per in-flight request.
+  func abandonRequest(id: RequestID)
 }
 
 extension Connection {
+  public func abandonRequest(id: RequestID) {}
+
   @available(*, deprecated, message: "Conformers should implement send(_:id:method:reply:)")
   public func send<Request: RequestType>(
     _ request: Request,

--- a/Sources/LanguageServerProtocolTransport/Connection+Send.swift
+++ b/Sources/LanguageServerProtocolTransport/Connection+Send.swift
@@ -23,6 +23,9 @@ extension Connection {
       return id
     } cancel: { requestID in
       self.send(CancelRequestNotification(id: requestID))
+      // Nobody awaits the reply anymore, so stop holding on to the state that would deliver it. A
+      // peer that has become unresponsive may not reply at all, even though it is required to.
+      self.abandonRequest(id: requestID)
     }
   }
 }

--- a/Sources/LanguageServerProtocolTransport/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolTransport/JSONRPCConnection.swift
@@ -32,6 +32,9 @@ import WinSDK
 import struct CDispatch.dispatch_fd_t
 #endif
 
+/// The maximum number of request IDs that `JSONRPCConnection` remembers as abandoned.
+private let maxAbandonedRequestIDs = 100
+
 /// A connection between a message handler (e.g. language server) in the same process as the connection object and a
 /// remote message handler (e.g. language client) that may run in another process using JSON RPC messages sent over a
 /// pair of in/out file descriptors.
@@ -106,6 +109,13 @@ public final class JSONRPCConnection: Connection {
   ///
   /// All accesses to `outstandingRequests` must be on `queue` to avoid race conditions.
   private nonisolated(unsafe) var outstandingRequests: [RequestID: OutstandingRequest] = [:]
+
+  /// The IDs of the requests that were removed from `outstandingRequests` by `abandonRequest(id:)`,
+  /// oldest first. A reply for one of these is expected and gets discarded instead of being logged
+  /// as a reply for an unknown request.
+  ///
+  /// All accesses to `abandonedRequestIDs` must be on `queue` to avoid race conditions.
+  private nonisolated(unsafe) var abandonedRequestIDs: [RequestID] = []
 
   /// A handler that will be called asynchronously when the connection is being
   /// closed.
@@ -512,7 +522,7 @@ public final class JSONRPCConnection: Connection {
       }
     case .response(let response, let id):
       guard let outstanding = outstandingRequests.removeValue(forKey: id) else {
-        logger.error("No outstanding requests for response ID \(id, privacy: .public)")
+        logUnknownResponse(id: id)
         return
       }
       outstanding.replyHandler(.success(response))
@@ -522,11 +532,25 @@ public final class JSONRPCConnection: Connection {
         return
       }
       guard let outstanding = outstandingRequests.removeValue(forKey: id) else {
-        logger.error("No outstanding requests for error response ID \(id, privacy: .public)")
+        logUnknownResponse(id: id)
         return
       }
       outstanding.replyHandler(.failure(error))
     }
+  }
+
+  /// Log that a reply was received for a request that is not in `outstandingRequests`, at a severity
+  /// that reflects whether the reply was expected.
+  ///
+  /// - Important: Must be called on `queue`
+  private func logUnknownResponse(id: RequestID) {
+    dispatchPrecondition(condition: .onQueue(queue))
+    guard let index = abandonedRequestIDs.firstIndex(of: id) else {
+      logger.error("No outstanding requests for response ID \(id, privacy: .public)")
+      return
+    }
+    abandonedRequestIDs.remove(at: index)
+    logger.debug("Discarding reply for abandoned request ID \(id, privacy: .public)")
   }
 
   /// Send the raw data to the receiving end of this connection.
@@ -736,6 +760,25 @@ public final class JSONRPCConnection: Connection {
         """
       )
       self.sendAssumingOnQueue(.request(request, method: method, id: id))
+    }
+  }
+
+  public func abandonRequest(id: RequestID) {
+    queue.async {
+      guard self.outstandingRequests.removeValue(forKey: id) != nil else {
+        // The peer already replied, so there is nothing to release and no reply left to discard.
+        return
+      }
+      logger.debug("Abandoning request \(id, privacy: .public) to \(self.name, privacy: .public)")
+      // Cap the number of tracked IDs: an unresponsive peer may never reply to an abandoned request,
+      // in which case its ID would be tracked forever, which is the unbounded growth that abandoning
+      // the request is meant to avoid in the first place. Dropping the oldest ID only means that a
+      // reply which arrives after `maxAbandonedRequestIDs` further requests were abandoned is logged
+      // as a reply for an unknown request.
+      if self.abandonedRequestIDs.count >= maxAbandonedRequestIDs {
+        self.abandonedRequestIDs.removeFirst()
+      }
+      self.abandonedRequestIDs.append(id)
     }
   }
 

--- a/Sources/LanguageServerProtocolTransport/LegacyNameFallbackConnection.swift
+++ b/Sources/LanguageServerProtocolTransport/LegacyNameFallbackConnection.swift
@@ -83,4 +83,11 @@ public final class LegacyNameFallbackConnection: Connection, Sendable {
   public func changeReceiveHandler(_ handler: any MessageHandler) {
     (inner as? JSONRPCConnection)?.changeReceiveHandler(handler)
   }
+
+  /// A request that is being retried under its legacy method name runs on `inner` under a request ID
+  /// of its own, which this cannot abandon. Retrying only happens after the peer replied to the
+  /// first attempt, so a peer that stops replying never reaches that state.
+  public func abandonRequest(id: RequestID) {
+    inner.abandonRequest(id: id)
+  }
 }

--- a/Sources/ToolsProtocolsSwiftExtensions/AsyncUtils.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/AsyncUtils.swift
@@ -94,6 +94,72 @@ extension Task where Failure == Never {
   }
 }
 
+/// The continuation of a task that is suspended by
+/// ``withCancellableCheckedThrowingContinuation(_:cancel:)``.
+///
+/// This wraps a `CheckedContinuation` so that the continuation is owned by the helper rather than by
+/// `operation`, which lets the helper resume the awaiting task itself.
+@_spi(SourceKitLSP) public struct CancellableContinuation<Success: Sendable>: Sendable {
+  private enum State: Sendable {
+    /// The `CheckedContinuation` that suspends the awaiting task does not exist yet.
+    case notStarted
+
+    /// The awaiting task is suspended and has not been resumed.
+    case waiting(CheckedContinuation<Success, any Error>)
+
+    /// The awaiting task has been resumed.
+    case resumed
+  }
+
+  private let state: ThreadSafeBox<State>
+
+  fileprivate init() {
+    self.state = ThreadSafeBox(initialValue: .notStarted)
+  }
+
+  /// Provide the continuation that suspends the awaiting task.
+  fileprivate func start(_ continuation: CheckedContinuation<Success, any Error>) {
+    state.withLock { state in
+      guard case .notStarted = state else {
+        preconditionFailure("CancellableContinuation was started twice")
+      }
+      state = .waiting(continuation)
+    }
+  }
+
+  /// Resume the awaiting task with the result of the operation.
+  ///
+  /// - Precondition: Must be called at most once.
+  public func resume<Failure: Error>(with result: Result<Success, Failure>) {
+    let continuation = state.withLock { state -> CheckedContinuation<Success, any Error> in
+      switch state {
+      case .notStarted:
+        preconditionFailure("CancellableContinuation was resumed before it was started")
+      case .waiting(let continuation):
+        state = .resumed
+        return continuation
+      case .resumed:
+        preconditionFailure("CancellableContinuation was resumed twice")
+      }
+    }
+    continuation.resume(with: result)
+  }
+
+  /// Resume the awaiting task by returning `value`.
+  ///
+  /// - Precondition: Must be called at most once.
+  public func resume(returning value: Success) {
+    resume(with: Result<Success, any Error>.success(value))
+  }
+
+  /// Resume the awaiting task by throwing `error`.
+  ///
+  /// - Precondition: Must be called at most once.
+  public func resume(throwing error: any Error) {
+    resume(with: Result<Success, any Error>.failure(error))
+  }
+}
+
 /// Allows the execution of a cancellable operation that returns the results
 /// via a completion handler.
 ///
@@ -101,11 +167,12 @@ extension Task where Failure == Never {
 ///
 /// If the task executing `withCancellableCheckedThrowingContinuation` gets
 /// cancelled, `cancel` is invoked with the handle that `operation` provided.
-@_spi(SourceKitLSP) public func withCancellableCheckedThrowingContinuation<Handle: Sendable, Result>(
-  _ operation: (_ continuation: CheckedContinuation<Result, any Error>) -> Handle,
+@_spi(SourceKitLSP) public func withCancellableCheckedThrowingContinuation<Handle: Sendable, Success: Sendable>(
+  _ operation: (_ continuation: CancellableContinuation<Success>) -> Handle,
   cancel: @Sendable (Handle) -> Void
-) async throws -> Result {
+) async throws -> Success {
   let handleWrapper = ThreadSafeBox<Handle?>(initialValue: nil)
+  let continuation = CancellableContinuation<Success>()
 
   @Sendable
   func callCancel() {
@@ -120,7 +187,10 @@ extension Task where Failure == Never {
   return try await withTaskCancellationHandler(
     operation: {
       try Task.checkCancellation()
-      return try await withCheckedThrowingContinuation { continuation in
+      return try await withCheckedThrowingContinuation { checkedContinuation in
+        // Hand the continuation to `continuation` before running `operation` because `operation` may
+        // resume it before it returns.
+        continuation.start(checkedContinuation)
         let handle = operation(continuation)
         handleWrapper.withLock { $0 = handle }
 

--- a/Sources/ToolsProtocolsSwiftExtensions/AsyncUtils.swift
+++ b/Sources/ToolsProtocolsSwiftExtensions/AsyncUtils.swift
@@ -107,6 +107,12 @@ extension Task where Failure == Never {
     /// The awaiting task is suspended and has not been resumed.
     case waiting(CheckedContinuation<Success, any Error>)
 
+    /// The awaiting task has been resumed with a `CancellationError`.
+    ///
+    /// The operation may still deliver a result that raced with the cancellation. That result is
+    /// discarded because the awaiting task is already resumed.
+    case cancelled
+
     /// The awaiting task has been resumed.
     case resumed
   }
@@ -129,20 +135,27 @@ extension Task where Failure == Never {
 
   /// Resume the awaiting task with the result of the operation.
   ///
+  /// If the awaiting task was cancelled it is already resumed, in which case `result` is discarded.
+  ///
   /// - Precondition: Must be called at most once.
   public func resume<Failure: Error>(with result: Result<Success, Failure>) {
-    let continuation = state.withLock { state -> CheckedContinuation<Success, any Error> in
+    let continuation = state.withLock { state -> CheckedContinuation<Success, any Error>? in
       switch state {
       case .notStarted:
         preconditionFailure("CancellableContinuation was resumed before it was started")
       case .waiting(let continuation):
         state = .resumed
         return continuation
+      case .cancelled:
+        // The result raced with the cancellation of the awaiting task, which has already been
+        // resumed with a `CancellationError`. Nobody is interested in the result anymore.
+        state = .resumed
+        return nil
       case .resumed:
         preconditionFailure("CancellableContinuation was resumed twice")
       }
     }
-    continuation.resume(with: result)
+    continuation?.resume(with: result)
   }
 
   /// Resume the awaiting task by returning `value`.
@@ -158,6 +171,22 @@ extension Task where Failure == Never {
   public func resume(throwing error: any Error) {
     resume(with: Result<Success, any Error>.failure(error))
   }
+
+  /// Resume the awaiting task by throwing a `CancellationError`, unless it has already been resumed.
+  ///
+  /// Unlike ``resume(with:)`` this may be called repeatedly because cancellation is observed both
+  /// through `withTaskCancellationHandler` and by re-checking `Task.isCancelled` once the operation
+  /// has been started.
+  fileprivate func cancel() {
+    let continuation = state.withLock { state -> CheckedContinuation<Success, any Error>? in
+      guard case .waiting(let continuation) = state else {
+        return nil
+      }
+      state = .cancelled
+      return continuation
+    }
+    continuation?.resume(throwing: CancellationError())
+  }
 }
 
 /// Allows the execution of a cancellable operation that returns the results
@@ -166,7 +195,11 @@ extension Task where Failure == Never {
 /// `operation` must invoke the continuation's `resume` method exactly once.
 ///
 /// If the task executing `withCancellableCheckedThrowingContinuation` gets
-/// cancelled, `cancel` is invoked with the handle that `operation` provided.
+/// cancelled, `cancel` is invoked with the handle that `operation` provided and
+/// the awaiting task is resumed with a `CancellationError` without waiting for
+/// `operation` to deliver a result. `operation` may never deliver one, eg. while
+/// it waits for a reply from an unresponsive peer. A result that arrives after
+/// the cancellation is discarded.
 @_spi(SourceKitLSP) public func withCancellableCheckedThrowingContinuation<Handle: Sendable, Success: Sendable>(
   _ operation: (_ continuation: CancellableContinuation<Success>) -> Handle,
   cancel: @Sendable (Handle) -> Void
@@ -182,6 +215,7 @@ extension Task where Failure == Never {
     if let handle = handleWrapper.takeValue() {
       cancel(handle)
     }
+    continuation.cancel()
   }
 
   return try await withTaskCancellationHandler(

--- a/Sources/ToolsProtocolsTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/ToolsProtocolsTestSupport/TestJSONRPCConnection.swift
@@ -167,6 +167,8 @@ package final class TestServer: MessageHandler {
   package func handle(_ notification: some NotificationType) {
     if notification is EchoNotification {
       self.client.send(notification)
+    } else if notification is CancelRequestNotification {
+      // Mimic a peer that doesn't act on cancellation.
     } else {
       fatalError("Unhandled notification")
     }
@@ -186,6 +188,8 @@ package final class TestServer: MessageHandler {
       } else {
         reply(.success(VoidResponse() as! Request.Response))
       }
+    } else if request is NoReplyRequest {
+      // Mimic an unresponsive peer by never calling `reply`.
     } else {
       fatalError("Unhandled request")
     }
@@ -195,8 +199,8 @@ package final class TestServer: MessageHandler {
 // MARK: Test requests
 
 private let testMessageRegistry = MessageRegistry(
-  requests: [EchoRequest.self, EchoError.self],
-  notifications: [EchoNotification.self, ShowMessageNotification.self]
+  requests: [EchoRequest.self, EchoError.self, NoReplyRequest.self],
+  notifications: [EchoNotification.self, ShowMessageNotification.self, CancelRequestNotification.self]
 )
 
 extension String: LanguageServerProtocol.ResponseType {}
@@ -223,6 +227,14 @@ package struct EchoError: RequestType {
     self.code = code
     self.message = message
   }
+}
+
+/// A request that `TestServer` never replies to, to mimic an unresponsive peer.
+package struct NoReplyRequest: RequestType {
+  package static let method: String = "test_server/no_reply"
+  package typealias Response = VoidResponse
+
+  package init() {}
 }
 
 package struct EchoNotification: NotificationType {

--- a/Tests/LanguageServerProtocolTransportTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTransportTests/ConnectionTests.swift
@@ -300,6 +300,22 @@ class ConnectionTests: XCTestCase {
 
     try await fulfillmentOfOrThrow(expectation)
   }
+
+  func testCancellationResumesRequestThatIsNeverRepliedTo() async throws {
+    let connectionToServer = connection.clientToServerConnection
+    let task = Task {
+      try await connectionToServer.send(NoReplyRequest())
+    }
+    // Wait for the request to reach the server so that the cancellation is observed by the
+    // cancellation handler instead of by the `Task.isCancelled` check that runs before the request is
+    // sent.
+    try await Task.sleep(for: .milliseconds(100))
+    task.cancel()
+
+    await assertThrowsError(try await task.value) { error in
+      XCTAssert(error is CancellationError, "Received unexpected error \(error)")
+    }
+  }
 }
 
 fileprivate extension JSONRPCConnection {

--- a/Tests/ToolsProtocolsSwiftExtensionsTests/AsyncUtilsTests.swift
+++ b/Tests/ToolsProtocolsSwiftExtensionsTests/AsyncUtilsTests.swift
@@ -207,9 +207,13 @@ final class AsyncUtilsTests: XCTestCase {
     task.cancel()
     try await fulfillmentOfOrThrow(cancelCalled)
 
-    // Cancellation only invokes `cancel`; the awaiting task is resumed by the operation's result.
+    // Cancellation resumes the awaiting task without waiting for the operation to deliver a result.
+    await assertThrowsError(try await task.value) { error in
+      XCTAssert(error is CancellationError, "Received unexpected error \(error)")
+    }
+
+    // A result that the operation delivers after the cancellation is discarded instead of resuming
+    // the awaiting task a second time.
     continuationBox.value?.resume(returning: 42)
-    let result = try await task.value
-    XCTAssertEqual(result, 42)
   }
 }

--- a/Tests/ToolsProtocolsSwiftExtensionsTests/AsyncUtilsTests.swift
+++ b/Tests/ToolsProtocolsSwiftExtensionsTests/AsyncUtilsTests.swift
@@ -177,4 +177,39 @@ final class AsyncUtilsTests: XCTestCase {
       XCTAssert(error is OperationError, "Received unexpected error \(error)")
     }
   }
+
+  func testWithCancellableCheckedThrowingContinuationReturnsResult() async throws {
+    let result = try await withCancellableCheckedThrowingContinuation { (continuation) -> Int in
+      continuation.resume(returning: 42)
+      return 1
+    } cancel: { _ in
+      XCTFail("cancel should not be called for an operation that is not cancelled")
+    }
+    XCTAssertEqual(result, 42)
+  }
+
+  func testWithCancellableCheckedThrowingContinuationCancelReceivesHandle() async throws {
+    let continuationBox = ThreadSafeBox<CancellableContinuation<Int>?>(initialValue: nil)
+    let operationStarted = self.expectation(description: "operation started")
+    let cancelCalled = self.expectation(description: "cancel called")
+
+    let task = Task {
+      try await withCancellableCheckedThrowingContinuation { (continuation) -> Int in
+        continuationBox.withLock { $0 = continuation }
+        operationStarted.fulfill()
+        return 7
+      } cancel: { handle in
+        XCTAssertEqual(handle, 7)
+        cancelCalled.fulfill()
+      }
+    }
+    try await fulfillmentOfOrThrow(operationStarted)
+    task.cancel()
+    try await fulfillmentOfOrThrow(cancelCalled)
+
+    // Cancellation only invokes `cancel`; the awaiting task is resumed by the operation's result.
+    continuationBox.value?.resume(returning: 42)
+    let result = try await task.value
+    XCTAssertEqual(result, 42)
+  }
 }


### PR DESCRIPTION
Cancelling a task that awaits `Connection.send` sent `$/cancelRequest` and then went back to waiting for a reply. A task suspended on a continuation is kept alive by that continuation, so the cancelled task never unwound — it and the request payload it captured stayed alive until the peer replied or the connection closed. A client talking to an unresponsive peer accumulates one such task per cancelled request, without bound, and `withTimeout` doesn't help: it returns to its caller when the timer fires, but all it does to the request is cancel it.

Resume the awaiting task with a `CancellationError` as soon as the cancellation is observed instead of waiting for a reply that may never arrive.

Cancellation and the peer's reply are concurrent, so a reply can arrive after the awaiting task was already resumed. `withCancellableCheckedThrowingContinuation` now hands `operation` a `CancellableContinuation` that it owns, which discards exactly that late result. Resuming twice for any other reason still traps, so a transport delivering two replies for one request remains a hard error rather than a silent no-op.

Since the reply handler stays registered once the awaiting task is resumed early, `Connection` gains an `abandonRequest(id:)` requirement that releases it. `JSONRPCConnection` removes the request from `outstandingRequests` and remembers its ID — capped, since an unresponsive peer may never reply — so a late reply is discarded quietly instead of logged as a reply for a request that was never sent. The default implementation does nothing, so conformers holding no per-request state are unaffected.

A peer is required by the LSP specification to reply to every request, including one cancelled with `$/cancelRequest`. This only stops the client from depending on a peer that no longer does.

rdar://184364916