### PR TITLE
Add missing LocalConnection precondition

### DIFF
--- a/Sources/LanguageServerProtocolTransport/LocalConnection.swift
+++ b/Sources/LanguageServerProtocolTransport/LocalConnection.swift
@@ -101,6 +101,7 @@ public final class LocalConnection: Connection, Sendable {
     guard let handler = queue.sync(execute: { handler }) else {
       return
     }
+    precondition(self.state == .started)
     handler.handle(notification)
   }
 


### PR DESCRIPTION
In https://github.com/swiftlang/sourcekit-lsp/pull/2751 @ahoppen noticed we had this precondition when sending a request, but not a notification, and it seems like the two methods should consistently enforce this.