### PR TITLE
Drop CI workflows for distros which don't have main toolchains

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
-      linux_os_versions: '["amazonlinux2", "bookworm", "noble", "jammy", "rhel-ubi9"]'
+      linux_os_versions: '["noble", "jammy", "rhel-ubi9"]'
       linux_pre_build_command: ./.github/scripts/prebuild.sh
       linux_swift_versions: '["nightly-main", "nightly-6.2"]'
       windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1'


### PR DESCRIPTION
amazon linux 2 and bookworm no longer have main snapshots available, so drop them from CI